### PR TITLE
Fix inability to delete entities via the web service

### DIFF
--- a/include/utils/utils.php
+++ b/include/utils/utils.php
@@ -1528,10 +1528,10 @@ function DeleteEntity($destinationModule, $sourceModule, $focus, $destinationRec
 		}
 	} else {
 		$currentUserPrivilegesModel = Users_Privileges_Model::getCurrentUserPrivilegesModel();
-		if (!$currentUserPrivilegesModel->isPermitted($module, 'Delete', $destinationRecordId)) {
+		if (!$currentUserPrivilegesModel->isPermitted($destinationModule, 'Delete', $destinationRecordId)) {
 			throw new AppException(vtranslate('LBL_PERMISSION_DENIED'));
 		}
-		$focus->trash($module, $destinationRecordId);
+		$focus->trash($destinationModule, $destinationRecordId);
 	}
 	$log->debug('Exiting DeleteEntity method ...');
 }


### PR DESCRIPTION
Trying to delete an account or other entity via the web service leads to an internal server error.

```
I, [2016-02-12T13:25:17.811792 #22324]  INFO -- : post http://localhost:8000/webservice.php
D, [2016-02-12T13:25:17.811843 #22324] DEBUG -- request: User-Agent: "Faraday v0.9.2"
Content-Type: "application/x-www-form-urlencoded"
D, [2016-02-12T13:25:17.811924 #22324] DEBUG -- request: id=11x137&operation=delete&sessionName=68f7c44b56bdcf2d33dd8
I, [2016-02-12T13:25:17.964263 #22324]  INFO -- Status: 200
D, [2016-02-12T13:25:17.964377 #22324] DEBUG -- response: Host: "localhost:8000"
Connection: "close"
X-Powered-By: "PHP/5.5.31"
Expires: "Thu, 19 Nov 1981 08:52:00 GMT"
Cache-Control: "no-store, no-cache, must-revalidate, post-check=0, pre-check=0"
Pragma: "no-cache"
Content-type: "application/json"
D, [2016-02-12T13:25:17.964787 #22324] DEBUG -- response: {"success"=>false,
 "error"=>
  {"code"=>"INTERNAL_SERVER_ERROR",
   "message"=>"Unknown Error while processing request"}}
```

The `$module` variable is just not defined. After changing it to `$destinationModule` things work as expected.