### PR TITLE
BUGFIX: Reports: xls - invalid currency display

### DIFF
--- a/modules/Reports/ReportUtils.php
+++ b/modules/Reports/ReportUtils.php
@@ -70,7 +70,7 @@ function IsDateField($reportColDetails)
 	if($reportColDetails == 'none'){
 		return false;
 	}
-	
+
 	list($tablename, $colname, $module_field, $fieldname, $typeOfData) = explode(":", $reportColDetails);
 	if ($typeOfData == "D") {
 		return true;
@@ -246,10 +246,18 @@ function getReportFieldValue($report, $picklistArray, $dbField, $valueArray, $fi
 	}
 
 	// Added to render html tag for description fields
-	if ($fieldInfo['uitype'] == '19' && ($module == 'Documents' || $module == 'Emails')) {
-		return $fieldvalue;
+	if (!($fieldInfo['uitype'] == '19' && ($module == 'Documents' || $module == 'Emails'))) {
+		$fieldvalue = htmlentities($fieldvalue, ENT_QUOTES, $default_charset);
 	}
-	return htmlentities($fieldvalue, ENT_QUOTES, $default_charset);
-}
 
-?>
+	if ($fieldvalue !== '-' && $fieldvalue !== null && $fieldvalue !== '') {
+		switch ($fieldType) {
+			case 'double':
+			case 'currency':
+				return (double)$fieldvalue;
+			case 'boolean':
+				return (bool)$fieldvalue;
+		}
+	}
+	return $fieldvalue;
+}


### PR DESCRIPTION
Reports: XLS - floating point numbers and currencies are displayed incorrectly in resulting file.

## Description
Numbers are outputted to resulting XLS as a string (values prefixed with ['] character) so that it is impassible to run calculations on them.

## Changes
- [ ] Bug fix: reports (xls) invalid display of number values
