### PR TITLE
Restrict Fieldaccess by role or user

### DIFF
--- a/install/install_schema/data.sql
+++ b/install/install_schema/data.sql
@@ -24992,6 +24992,7 @@ insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`desc
 insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (52,15,'LBL_DATAACCESS','adminIcon-recording-control','LBL_DATAACCESS_DESCRIPTION','index.php?module=DataAccess&parent=Settings&view=Index',2,0,0);
 insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (53,4,'LangManagement','adminIcon-languages-and-translations','LBL_LANGMANAGEMENT_DESCRIPTION','index.php?module=LangManagement&parent=Settings&view=Index',1,0,0);
 insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (54,1,'GlobalPermission','adminIcon-special-access','LBL_GLOBALPERMISSION_DESCRIPTION','index.php?module=GlobalPermission&parent=Settings&view=Index',7,0,0);
+insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (103,1,'GlobalFieldAccess','adminIcon-special-access','LBL_GLOBALPERMISSION_FIELDACCESS','index.php?module=GlobalPermission&parent=Settings&view=FieldPermissions',7,0,0);
 insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (56,13,'Search Setup','adminIcon-search-configuration','LBL_SEARCH_SETUP_DESCRIPTION','index.php?module=Search&parent=Settings&view=Index',1,0,0);
 insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (57,13,'CustomView','adminIcon-filters-configuration','LBL_CUSTOMVIEW_DESCRIPTION','index.php?module=CustomView&parent=Settings&view=Index',2,0,0);
 insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`description`,`linkto`,`sequence`,`active`,`pinned`) values (58,2,'Widgets','adminIcon-modules-widgets','LBL_WIDGETS_DESCRIPTION','index.php?module=Widgets&parent=Settings&view=Index',3,0,1);
@@ -25038,7 +25039,7 @@ insert  into `vtiger_settings_field`(`fieldid`,`blockid`,`name`,`iconpath`,`desc
 
 /*Data for the table `vtiger_settings_field_seq` */
 
-insert  into `vtiger_settings_field_seq`(`id`) values (102);
+insert  into `vtiger_settings_field_seq`(`id`) values (103);
 
 /*Data for the table `vtiger_sharedcalendar` */
 

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -4823,6 +4823,8 @@ CREATE TABLE `vtiger_field` (
   `header_field` varchar(15) DEFAULT NULL,
   `maxlengthtext` smallint(3) unsigned DEFAULT '0',
   `maxwidthcolumn` smallint(3) unsigned DEFAULT '0',
+  `user_permissions` varchar(255) DEFAULT NULL,
+  `role_permissions` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`fieldid`),
   KEY `field_tabid_idx` (`tabid`),
   KEY `field_fieldname_idx` (`fieldname`),

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -3828,6 +3828,8 @@ CREATE TABLE `vtiger_crmentity` (
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `was_read` tinyint(1) DEFAULT '0',
   `users` text,
+  `user_permissions` varchar(255) DEFAULT NULL,
+  `role_permissions` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`crmid`),
   KEY `crmentity_smcreatorid_idx` (`smcreatorid`),
   KEY `crmentity_modifiedby_idx` (`modifiedby`),

--- a/modules/Settings/GlobalPermission/actions/SaveField.php
+++ b/modules/Settings/GlobalPermission/actions/SaveField.php
@@ -1,0 +1,31 @@
+<?php
+
+class Settings_GlobalPermission_SaveField_Action extends Settings_Vtiger_Save_Action {
+
+    public function checkPermission(Vtiger_Request $request)
+    {
+        $currentUser = Users_Record_Model::getCurrentUserModel();
+        if (!$currentUser->isAdminUser()) {
+            throw new \Exception\AppException('LBL_PERMISSION_DENIED');
+        }
+    }
+
+    public function process(Vtiger_Request $request)
+    {
+        $fieldValues = $request->get('field-access-user');
+        foreach($fieldValues as $fieldId => $values) {
+            $instance = Vtiger_Field_Model::getInstance($fieldId);
+            $instance->wipeAccessRestrictionsForUsers();
+            $instance->allowUsers($values);
+        }
+
+
+        $fieldValues = $request->get('field-access-role');
+        foreach($fieldValues as $fieldId => $values) {
+            $instance = Vtiger_Field_Model::getInstance($fieldId);
+            $instance->wipeAccessRestrictionsForRoles();
+            $instance->allowRoles($values);
+        }
+        header('location:index.php');
+    }
+}

--- a/modules/Settings/GlobalPermission/views/FieldPermissions.php
+++ b/modules/Settings/GlobalPermission/views/FieldPermissions.php
@@ -1,0 +1,32 @@
+<?php
+/* +***********************************************************************************************************************************
+ * The contents of this file are subject to the YetiForce Public License Version 1.1 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ * See the License for the specific language governing rights and limitations under the License.
+ * The Original Code is YetiForce.
+ * The Initial Developer of the Original Code is YetiForce. Portions created by YetiForce are Copyright (C) www.yetiforce.com.
+ * All Rights Reserved.
+ * *********************************************************************************************************************************** */
+
+class Settings_GlobalPermission_FieldPermissions_View extends Settings_Vtiger_Index_View
+{
+    public function process(Vtiger_Request $request)
+    {
+        $moduleName = $request->getModule();
+        $qualifiedModuleName = $request->getModule(false);
+
+        $modules = Vtiger_Module_Model::getAll();
+        $viewer = $this->getViewer($request);
+        $currentUser = Users_Record_Model::getCurrentUserModel();
+        $roles = Settings_Roles_Record_Model::getAll();
+        $users = Users_Record_Model::getAll();
+        $viewer->assign('QUALIFIED_MODULE', $qualifiedModuleName);
+        $viewer->assign('MODULE', $moduleName);
+        $viewer->assign('MODULES', $modules);
+        $viewer->assign('ROLES', $roles);
+        $viewer->assign('USER_MODEL', $currentUser);
+        $viewer->assign('USERS', $users);
+        $viewer->view('FieldPermission.tpl', $qualifiedModuleName);
+    }
+}

--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -1437,4 +1437,44 @@ class Users extends CRMEntity
 			$em->triggerEvent("vtiger.entity.aftersave.final", $entityData);
 		}
 	}
+
+			
+    /**		
+     * Checks if the current user can see a field		
+     *		
+     * @param int $fieldId		
+     * @return bool		
+     */		
+	public function hasAccessToField($fieldId) {		
+	    $db = PearDatabase::getInstance();		
+        $q = 'SELECT role_permissions, user_permissions FROM vtiger_field WHERE fieldid = ?';		
+        $r = $db->pquery($q, [$fieldId]);		
+        $access = true;		
+        $row = $db->fetch_array($r);		
+        if(!$this->checkFieldAccess($row['role_permissions'])) {		
+            $access = false;		
+        }		
+        if($this->checkFieldAccess($row['user_permissions'])) { // override role permission if explicitly granted to user		
+            if($row['user_permissions'] === null && !$access) { // if there are no user permissions and access is denied by group		
+                $access = false;		
+            } else {		
+                $access = true;		
+            }		
+        } else { // if access is restricted explicitly to user but role access might be granted it is overridden		
+            $access = false;		
+        }		
+	    return $access;		
+    }		
+    protected function checkFieldAccess($data) {		
+        if($data === null || $this->is_admin == 'on') {		
+            return true;		
+        }		
+        $data = json_decode($data, true);		
+        foreach($data as $id => $permission) {		
+            if($id === $this->id || $id === $this->roleid) {		
+                return  true;		
+            }		
+        }		
+        return false;		
+    }
 }

--- a/vtlib/Vtiger/Functions.php
+++ b/vtlib/Vtiger/Functions.php
@@ -342,6 +342,32 @@ class Functions
 		return isset(self::$moduleFieldInfoByNameCache[$module]) ? self::$moduleFieldInfoByNameCache[$module] : NULL;
 	}
 
+	protected static function isAllowed($module, $record = null) {		
+	    $permissions = null;		
+        if($module == 'Users') { // We don't have a user if we haven't ran through the users module yet		
+            return true;		
+        }		
+        $user = vglobal('current_user');		
+        if(static::userIsAdministrator($user)) { // admin is allowed to everything by default		
+            return true;		
+        }		
+        if($record !== null) {		
+            return $user->hasAccessToField($record['fieldid']);		
+        }		
+        return true;		
+    }		
+    
+    protected static function removeEntriesFromCacheByPermission($module) {		
+        if($module == 'Users') {		
+            return;		
+        }		
+        foreach(static::$moduleFieldInfoByNameCache[$module] as $name => $data) {		
+            if(!static::isAllowed($module, $data)) {		
+                unset(static::$moduleFieldInfoByNameCache[$module][$name]);		
+            }		
+        }		
+    }
+
 	public static function getModuleFieldInfoWithId($fieldid)
 	{
 		$adb = \PearDatabase::getInstance();


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
To restrict access to field e.g. "Admin Notices" we added a functionality which explicitly grants access to certain fields by role.

If nothing is restricted it's free for everyone.

If a role(or more) is selected only those roles can access the field.
If a user is explicitly added that user also gains access to that field.

Usersettings override rolesettings.

Eg. "Admin Notices" is visible only for "IT-Desk" it is visible ONLY for the "IT-Desk" role and the hierarchical higher groups.
If you add "John Doe" to the permission list it will also be visible for "John Doe" even though he is not member of the "IT-Desk" role.

## Testing
Productive Use

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist

- [x] My code is written according to the guidelines found [here] (https://yetiforce.com/en/developer-documentation/standards/167-how-to-create-php-files.html).
- [x] I have signed the Contributor Licence Agreement between me and YetiForce.
