### PR TITLE
fix smtp options unusable

### DIFF
--- a/languages/de_de/Settings/MailSmtp.php
+++ b/languages/de_de/Settings/MailSmtp.php
@@ -30,5 +30,5 @@ $languageStrings = [
 	'LBL_CREATE_SMTP' => 'SMTP anlegen',
 	'LBL_SMTP_DETAIL' => 'SMTP Detail',
 	'LBL_INDIVIDUAL_DELIVERY_INFO' => 'E-Mails werden je Empfänger einzel versendet',
-	'LBL_OPTIONS_INFO' => "Bespiel zusätzlicher Parameter:<br /> 'ssl' => [<br />'verify_peer'  => true,<br />'verify_depth' => 3,<br />'allow_self_signed' => true,<br />'peer_name' => 'smtp.example.com',<br />'cafile' => '/etc/ssl/ca_cert.pem',<br />]",
+	'LBL_OPTIONS_INFO' => "Beispiel zusätzlicher Parameter (Json):<br /> {<br />  &quot;ssl&quot;: {<br />    &quot;verify_peer&quot;:false,<br />    &quot;verify_peer_name&quot;:false,<br />    &quot;allow_self_signed&quot;:true<br />  }<br />}",
 ];

--- a/languages/en_us/Settings/MailSmtp.php
+++ b/languages/en_us/Settings/MailSmtp.php
@@ -30,5 +30,5 @@ $languageStrings = [
 	'LBL_CREATE_SMTP' => 'Create SMTP',
 	'LBL_SMTP_DETAIL' => 'SMTP detail',
 	'LBL_INDIVIDUAL_DELIVERY_INFO' => 'Emails will be sent individually for each recipient',
-	'LBL_OPTIONS_INFO' => "Exemplary additional parameters:<br /> 'ssl' => [<br />'verify_peer'  => true,<br />'verify_depth' => 3,<br />'allow_self_signed' => true,<br />'peer_name' => 'smtp.example.com',<br />'cafile' => '/etc/ssl/ca_cert.pem',<br />]",
+	'LBL_OPTIONS_INFO' => "Exemplary additional parameters (Json):<br /> {<br />  &quot;ssl&quot;: {<br />    &quot;verify_peer&quot;:false,<br />    &quot;verify_peer_name&quot;:false,<br />    &quot;allow_self_signed&quot;:true<br />  }<br />}",
 ];

--- a/languages/fr_fr/Settings/MailSmtp.php
+++ b/languages/fr_fr/Settings/MailSmtp.php
@@ -30,5 +30,5 @@ $languageStrings = [
 	'LBL_CREATE_SMTP' => 'Create SMTP',
 	'LBL_SMTP_DETAIL' => 'SMTP detail',
 	'LBL_INDIVIDUAL_DELIVERY_INFO' => 'Emails will be sent individually for each recipient',
-	'LBL_OPTIONS_INFO' => "Exemplary additional parameters:<br /> 'ssl' => [<br />'verify_peer'  => true,<br />'verify_depth' => 3,<br />'allow_self_signed' => true,<br />'peer_name' => 'smtp.example.com',<br />'cafile' => '/etc/ssl/ca_cert.pem',<br />]",
+	'LBL_OPTIONS_INFO' => "Exemplary additional parameters(Json):<br /> {<br />  &quot;ssl&quot;: {<br />    &quot;verify_peer&quot;:false,<br />    &quot;verify_peer_name&quot;:false,<br />    &quot;allow_self_signed&quot;:true<br />  }<br />}",
 ];

--- a/languages/pl_pl/Settings/MailSmtp.php
+++ b/languages/pl_pl/Settings/MailSmtp.php
@@ -29,5 +29,5 @@ $languageStrings = [
 	'LBL_CREATE_SMTP' => 'Utwórz SMTP',
 	'LBL_SMTP_DETAIL' => 'Szczegóły SMTP',
 	'LBL_INDIVIDUAL_DELIVERY_INFO' => 'Wiadomości email będą wysyłane oddzielnie do każdego z odbiorców',
-	'LBL_OPTIONS_INFO' => "Przykładowe parametry dodatkowe:<br /> 'ssl' => [<br />'verify_peer'  => true,<br />'verify_depth' => 3,<br />'allow_self_signed' => true,<br />'peer_name' => 'smtp.example.com',<br />'cafile' => '/etc/ssl/ca_cert.pem',<br />]",
+	'LBL_OPTIONS_INFO' => "Przykładowe parametry dodatkowe(Json):<br /> {<br />  &quot;ssl&quot;: {<br />    &quot;verify_peer&quot;:false,<br />    &quot;verify_peer_name&quot;:false,<br />    &quot;allow_self_signed&quot;:true<br />  }<br />}",
 ];

--- a/languages/ru_ru/Settings/MailSmtp.php
+++ b/languages/ru_ru/Settings/MailSmtp.php
@@ -30,5 +30,5 @@ $languageStrings = [
 	'LBL_CREATE_SMTP' => 'Create SMTP',
 	'LBL_SMTP_DETAIL' => 'SMTP detail',
 	'LBL_INDIVIDUAL_DELIVERY_INFO' => 'Emails will be sent individually for each recipient',
-	'LBL_OPTIONS_INFO' => "Exemplary additional parameters:<br /> 'ssl' => [<br />'verify_peer'  => true,<br />'verify_depth' => 3,<br />'allow_self_signed' => true,<br />'peer_name' => 'smtp.example.com',<br />'cafile' => '/etc/ssl/ca_cert.pem',<br />]",
+	'LBL_OPTIONS_INFO' => "Exemplary additional parameters(Json):<br /> {<br />  &quot;ssl&quot;: {<br />    &quot;verify_peer&quot;:false,<br />    &quot;verify_peer_name&quot;:false,<br />    &quot;allow_self_signed&quot;:true<br />  }<br />}",
 ];

--- a/vendor/yetiforce/Mailer.php
+++ b/vendor/yetiforce/Mailer.php
@@ -180,7 +180,7 @@ class Mailer
 		$this->mailer->Username = $this->smtp['username'];
 		$this->mailer->Password = $this->smtp['password'];
 		if ($this->smtp['options']) {
-			$this->mailer->SMTPOptions = $this->smtp['options'];
+			$this->mailer->SMTPOptions = Json::decode($this->smtp['options'], true);
 		}
 		if ($this->smtp['from_email']) {
 			$this->mailer->From = $this->smtp['from_email'];


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
<!--- Provide a detailed description of what changes are included in your pull request -->

### SMTP Mailer
For now SMTP options are impossible to set, since a php array is expected, but cannot be created via webform or sql field content. 
Switched to have that as Json string which is converted to php array.

Json Sample in language file also reflects new usage.

## Testing
<!--- Please describe in detail how to test your changes. -->
self tested and working with smtp and self signed cert

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [x] My code is written according to the guidelines found [here] (https://yetiforce.com/en/developer-documentation/standards/167-how-to-create-php-files.html).
- [x] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
