### PR TITLE
Fixed possible PHP syntax errors in User privledge files

### DIFF
--- a/modules/Users/CreateUserPrivilegeFile.php
+++ b/modules/Users/CreateUserPrivilegeFile.php
@@ -323,6 +323,8 @@ function constructArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -348,6 +350,8 @@ function constructSingleStringValueArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -373,6 +377,8 @@ function constructSingleStringKeyAndValueArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -390,6 +396,8 @@ function constructSingleArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -407,6 +415,8 @@ function constructSingleCharArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -428,6 +438,8 @@ function constructTwoDimensionalArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -449,6 +461,8 @@ function constructTwoDimensionalValueArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -470,6 +484,8 @@ function constructTwoDimensionalCharIntSingleArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 
@@ -491,6 +507,8 @@ function constructTwoDimensionalCharIntSingleValueArray($var)
 		}
 		$code .= ']';
 		return $code;
+	} else {
+		return '[]';
 	}
 }
 


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
Added a fallback of returning an empty array if the element is not an array rather than returning just null. Sometimes a property would be put into the file as "$variable=;", which would cause an exception. We only had this occur on very basic users after importing.

## Testing
We kept having syntax errors during import. I performed this patch and we were able to continue import. Files no longer had the syntax errors.

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [X] My code is written according to the guidelines found [here] (https://yetiforce.com/en/developer-documentation/standards/167-how-to-create-php-files.html).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
