### PR TITLE
Methods and properties visibility should always be explicitly defined

### DIFF
--- a/include/runtime/Controller.php
+++ b/include/runtime/Controller.php
@@ -25,9 +25,9 @@ abstract class Vtiger_Controller
 		return true;
 	}
 
-	abstract function getViewer(\App\Request $request);
+	abstract public function getViewer(\App\Request $request);
 
-	abstract function process(\App\Request $request);
+	abstract public function process(\App\Request $request);
 
 	public function validateRequest(\App\Request $request)
 	{
@@ -142,7 +142,7 @@ abstract class Vtiger_Action_Controller extends Vtiger_Controller
 		parent::__construct();
 	}
 
-	abstract function checkPermission(\App\Request $request);
+	abstract public function checkPermission(\App\Request $request);
 
 	public function getViewer(\App\Request $request)
 	{

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -219,7 +219,7 @@ class ReportRun extends CRMEntity
 {
 
 	// Maximum rows that should be emitted in HTML view.
-	static $HTMLVIEW_MAX_ROWS = 1000;
+	public static $HTMLVIEW_MAX_ROWS = 1000;
 	public $reportid;
 	public $primarymodule;
 	public $secondarymodule;


### PR DESCRIPTION
 Methods and properties visibility should always be explicitly defined 