### PR TITLE
fix: No sorting for fieldnames with HTML entities in reports

### DIFF
--- a/modules/Reports/models/Record.php
+++ b/modules/Reports/models/Record.php
@@ -486,14 +486,14 @@ class Reports_Record_Model extends Vtiger_Record_Model
 		if (!empty($sortFields)) {
 			$i = 0;
 			foreach ($sortFields as $fieldInfo) {
-				$columnname = html_entity_decode($fieldInfo[0]);
+				$columnName = App\Purifier::decodeHtml($fieldInfo[0]);
 				$db->pquery('INSERT INTO vtiger_reportsortcol(sortcolid, reportid, columnname, sortorder) VALUES (?,?,?,?)', [$i, $this->getId(), $columnname, $fieldInfo[1]]);
-				if (IsDateField($columnname)) {
+				if (IsDateField($columnName)) {
 					if (empty($fieldInfo[2])) {
 						$fieldInfo[2] = 'None';
 					}
-					$db->pquery("INSERT INTO vtiger_reportgroupbycolumn(reportid, sortid, sortcolname, dategroupbycriteria)
-                        VALUES(?,?,?,?)", [$this->getId(), $i, $columnname, $fieldInfo[2]]);
+					$db->pquery('INSERT INTO vtiger_reportgroupbycolumn(reportid, sortid, sortcolname, dategroupbycriteria)
+                        VALUES(?,?,?,?)', [$this->getId(), $i, $columnName, $fieldInfo[2]]);
 				}
 				$i++;
 			}

--- a/modules/Reports/models/Record.php
+++ b/modules/Reports/models/Record.php
@@ -486,13 +486,14 @@ class Reports_Record_Model extends Vtiger_Record_Model
 		if (!empty($sortFields)) {
 			$i = 0;
 			foreach ($sortFields as $fieldInfo) {
-				$db->pquery('INSERT INTO vtiger_reportsortcol(sortcolid, reportid, columnname, sortorder) VALUES (?,?,?,?)', [$i, $this->getId(), $fieldInfo[0], $fieldInfo[1]]);
-				if (IsDateField($fieldInfo[0])) {
+				$columnname = html_entity_decode($fieldInfo[0]);
+				$db->pquery('INSERT INTO vtiger_reportsortcol(sortcolid, reportid, columnname, sortorder) VALUES (?,?,?,?)', [$i, $this->getId(), $columnname, $fieldInfo[1]]);
+				if (IsDateField($columnname)) {
 					if (empty($fieldInfo[2])) {
 						$fieldInfo[2] = 'None';
 					}
 					$db->pquery("INSERT INTO vtiger_reportgroupbycolumn(reportid, sortid, sortcolname, dategroupbycriteria)
-                        VALUES(?,?,?,?)", [$this->getId(), $i, $fieldInfo[0], $fieldInfo[2]]);
+                        VALUES(?,?,?,?)", [$this->getId(), $i, $columnname, $fieldInfo[2]]);
 				}
 				$i++;
 			}


### PR DESCRIPTION
## Description
<!--- Provide a detailed description of what changes are included in your pull request -->
for some fields (those with HTML entities in their name) no sorting is done in reports.
Those field names are inside the request and so replaced to their applicable characters. But there was no converting back to the original char.

E.g.  (\$amp; -> &)
~~~
Tickets and "vtiger_activity:date_start:Calendar__Start__Date__&amp;__Time:date_start:DT" -> "vtiger_activity:date_start:Calendar__Start__Date__&__Time:date_start:DT"
~~~