### PR TITLE
Ok-icon repaired in calender's remainders.

### DIFF
--- a/layouts/basic/modules/Calendar/Reminders.tpl
+++ b/layouts/basic/modules/Calendar/Reminders.tpl
@@ -8,7 +8,7 @@
 			{assign var=END_TIME value=$RECORD->get('time_end')}
 			{assign var=RECORD_ID value=$RECORD->getId()}
 			<div class="panel picklistCBr_Calendar_activitytype_{\App\Purifier::encodeHtml($RECORD->get('activitytype'))}" data-record="{$RECORD_ID}">
-				<div class="panel-heading picklistCBg_Calendar_activitytype_{\App\Purifier::encodeHtml($RECORD->get('activitytype'))}"
+				<div class="panel-heading picklistCBg_Calendar_activitytype_{\App\Purifier::encodeHtml($RECORD->get('activitytype'))}">
 					 <button class="btn btn-success btn-xs pull-right showModal" data-url="index.php?module=Calendar&view=ActivityStateModal&trigger=Reminders&record={$RECORD->getId()}">
 						<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
 					</button>

--- a/public_html/layouts/basic/skins/style.css
+++ b/public_html/layouts/basic/skins/style.css
@@ -6013,6 +6013,7 @@ border1px{
 		margin-right: 0;
 		margin-bottom: 10px;
 	}
+}
 .popover.activities{
 	min-width: 400px;
 }


### PR DESCRIPTION
Ok-icon repaired in calender's remainders.
Was:
![okwas](https://user-images.githubusercontent.com/31520119/33767902-2adaa728-dc24-11e7-9741-a02f45fbc475.png)
Now:
![oknow](https://user-images.githubusercontent.com/31520119/33767907-30d3d9f6-dc24-11e7-8fa0-334a33b928bd.png)
