### PR TITLE
fix bad filename for exported modules

### DIFF
--- a/vtlib/Vtiger/Zip.php
+++ b/vtlib/Vtiger/Zip.php
@@ -28,7 +28,7 @@ class Zip extends \Dzip
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header("Cache-Control: private", false);
 		header("Content-Type: application/zip");
-		header("Content-Disposition: attachment; filename='" . basename($zipfileName) . "';");
+		header('Content-Disposition: attachment; filename="' . basename($zipfileName) . '";');
 		// For details on this workaround check here the ticket
 		// http://trac.vtiger.com/cgi-bin/trac.cgi/ticket/5298
 		$disk_file_size = filesize($zipfileName);


### PR DESCRIPTION
'foo,zip' -> foo.zip (single quotes become part of the filename)
