### PR TITLE
jQuery 3 ajax.success fix

### DIFF
--- a/public_html/layouts/resources/fields/MultiImage.js
+++ b/public_html/layouts/resources/fields/MultiImage.js
@@ -161,8 +161,8 @@ class MultiImage {
 			}
 		});
 		data.submit()
-			.success(this.success.bind(this))
-			.error(this.error.bind(this));
+			.done(this.success.bind(this))
+			.fail(this.error.bind(this));
 	}
 
 	/**


### PR DESCRIPTION
fix jquery ajax.success is not a function after jquery migrate removal