### PR TITLE
lazy loader threshold was set to 0, loading all visible widgets bug fix

### DIFF
--- a/public_html/layouts/basic/modules/Vtiger/resources/DashBoard.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/DashBoard.js
@@ -97,11 +97,15 @@ $.Class("Vtiger_DashBoard_Js", {
 	loadWidgets: function () {
 		const thisInstance = this;
 		thisInstance.getContainer().find('.dashboardWidget').Lazy({
+			threshold: 0,
 			appendScroll: $('.mainBody'),
 			widgetLoader(element) {
 				thisInstance.loadWidget(element);
 			},
 		});
+		// jquery lazy hack to load all dashboard widget on tab click
+		const scrollTop = $('.mainBody').scrollTop();
+		$('.mainBody').scrollTop(scrollTop + 1).scrollTop(scrollTop);
 	},
 	loadWidget: function (widgetContainer) {
 		var thisInstance = this;


### PR DESCRIPTION
![2018-04-18_10-41-48](https://user-images.githubusercontent.com/36499752/38921087-251d62c0-42f5-11e8-800c-f9084fdfc8ee.gif)
