### PR TITLE
division by zero in charts (average type) fixed

### DIFF
--- a/modules/Vtiger/models/ChartFilter.php
+++ b/modules/Vtiger/models/ChartFilter.php
@@ -821,7 +821,7 @@ class Vtiger_ChartFilter_Model extends Vtiger_Widget_Model
 			foreach ($this->data as $dividingValue => &$dividing) {
 				foreach ($dividing as $groupValue => &$group) {
 					if ($group['avg']) {
-						$group['avg'] = (float) $group['avg'] / $this->numRows[$groupValue][$dividingValue];
+						$group['avg'] = (float) $group['avg'] / $this->numRows[$dividingValue][$groupValue];
 					}
 				}
 			}


### PR DESCRIPTION
![firefox_2018-04-25_15-35-05](https://user-images.githubusercontent.com/36499752/39297521-08f7417e-4944-11e8-8856-ff225aa59c5a.jpg)
