### PR TITLE
Fixed implode arguments in roles record model and other fix

### DIFF
--- a/modules/Settings/Roles/models/Record.php
+++ b/modules/Settings/Roles/models/Record.php
@@ -313,7 +313,9 @@ class Settings_Roles_Record_Model extends Settings_Vtiger_Record_Model
 			$this->set('parentrole', $parentRole->getParentRoleString() . '::' . $roleId);
 		}
 		$searchunpriv = $this->get('searchunpriv');
-		$searchunpriv = implode(',', empty($searchunpriv) ? [] : $searchunpriv);
+		if (is_array($searchunpriv)) {
+			$searchunpriv = implode(',', $searchunpriv);
+		}
 		$permissionsRelatedField = $this->get('permissionsrelatedfield');
 		$permissionsRelatedField = implode(',', empty($permissionsRelatedField) ? [] : $permissionsRelatedField);
 		$values = [

--- a/vtlib/Vtiger/LayoutExport.php
+++ b/vtlib/Vtiger/LayoutExport.php
@@ -47,18 +47,18 @@ class LayoutExport extends Package
 	 * @param string Zipfilename to use
 	 * @param bool True for sending the output as download
 	 */
-	public function export($layoutName, $todir = '', $zipfilename = '', $directDownload = false)
+	public function export(\vtlib\Module $moduleInstance, $todir = '', $zipfilename = '', $directDownload = false)
 	{
-		$this->__initExport($layoutName);
+		$this->__initExport($moduleInstance->name);
 
 		// Call layout export function
-		$this->exportLayout($layoutName);
+		$this->exportLayout($moduleInstance->name);
 
 		$this->__finishExport();
 
 		// Export as Zip
 		if ($zipfilename == '') {
-			$zipfilename = "$layoutName-" . date('YmdHis') . '.zip';
+			$zipfilename = "$moduleInstance->name-" . date('YmdHis') . '.zip';
 		}
 		$zipfilename = "$this->_export_tmpdir/$zipfilename";
 
@@ -66,7 +66,7 @@ class LayoutExport extends Package
 		// Add manifest file
 		$zip->addFile($this->__getManifestFilePath(), 'manifest.xml');
 		// Copy module directory
-		$zip->addDirectory('layouts/' . $layoutName);
+		$zip->addDirectory('layouts/' . $moduleInstance->name);
 		if ($directDownload) {
 			$zip->download();
 		} else {


### PR DESCRIPTION
Fixed implode arguments in roles record model and fixed declaration of vtlib\LayoutExport::export which should be compatible with vtlib\PackageExport::export
