### PR TITLE
u-text-ellipsis--no-hover for tooltips / popovers integration

### DIFF
--- a/public_html/layouts/basic/styles/components/_Utilities.scss
+++ b/public_html/layouts/basic/styles/components/_Utilities.scss
@@ -37,7 +37,11 @@
 		}
 	}
 }
-
+.u-text-ellipsis--no-hover {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .u-text-underline {
 	text-decoration: underline;
 }


### PR DESCRIPTION
![chrome_2018-06-01_13-28-26](https://user-images.githubusercontent.com/36499752/40838707-b84f6526-659f-11e8-9ee3-66d679b43a2c.jpg)
