### PR TITLE
ellipsis popover component, chart widget header ellipsis popover

### DIFF
--- a/layouts/basic/modules/Accounts/dashboards/AccountsByIndustry.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/AccountsByIndustry.tpl
@@ -1,6 +1,6 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Accounts/dashboards/AccountsByIndustry.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/AccountsByIndustry.tpl
@@ -2,7 +2,9 @@
 <div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Accounts/dashboards/AccountsByIndustry.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/AccountsByIndustry.tpl
@@ -1,16 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/Accounts/dashboards/NeglectedAccounts.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/NeglectedAccounts.tpl
@@ -2,7 +2,9 @@
 <div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Accounts/dashboards/NeglectedAccounts.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/NeglectedAccounts.tpl
@@ -1,27 +1,21 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{if \App\Privilege::isPermitted('Accounts', 'CreateView')}
-					<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Accounts'); return false;">
-						<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-					</a>
-				{/if}
-				<a class="btn btn-sm btn-light" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
-					<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+			{if \App\Privilege::isPermitted('Accounts', 'CreateView')}
+				<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Accounts'); return false;">
+					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
 				</a>
-				{if !$WIDGET->isDefault()}
-					<a class="btn btn-sm btn-light" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
-						<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
-					</a>
-				{/if}
-			</div>
+			{/if}
+			<a class="btn btn-sm btn-light" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
+				<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+			</a>
+			{if !$WIDGET->isDefault()}
+				<a class="btn btn-sm btn-light" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
+					<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
+				</a>
+			{/if}
 		</div>
 	</div>
 	<hr class="widgetHr" />

--- a/layouts/basic/modules/Accounts/dashboards/NeglectedAccounts.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/NeglectedAccounts.tpl
@@ -1,8 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
-		<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+		<div class="d-inline-flex">
 			{if \App\Privilege::isPermitted('Accounts', 'CreateView')}
 				<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Accounts'); return false;">
 					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>

--- a/layouts/basic/modules/Accounts/dashboards/NewAccounts.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/NewAccounts.tpl
@@ -1,27 +1,21 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{if \App\Privilege::isPermitted('Accounts', 'CreateView')}
-					<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Accounts'); return false;">
-						<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-					</a>
-				{/if}
-				<a class="btn btn-sm btn-light" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
-					<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+			{if \App\Privilege::isPermitted('Accounts', 'CreateView')}
+				<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Accounts'); return false;">
+					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
 				</a>
-				{if !$WIDGET->isDefault()}
-					<a class="btn btn-sm btn-light" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
-						<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
-					</a>
-				{/if}
-			</div>
+			{/if}
+			<a class="btn btn-sm btn-light" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
+				<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+			</a>
+			{if !$WIDGET->isDefault()}
+				<a class="btn btn-sm btn-light" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
+					<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
+				</a>
+			{/if}
 		</div>
 	</div>
 	<hr class="widgetHr" />

--- a/layouts/basic/modules/Accounts/dashboards/NewAccounts.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/NewAccounts.tpl
@@ -1,8 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
-		<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+		<div class="d-inline-flex">
 			{if \App\Privilege::isPermitted('Accounts', 'CreateView')}
 				<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Accounts'); return false;">
 					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>

--- a/layouts/basic/modules/Accounts/dashboards/NewAccounts.tpl
+++ b/layouts/basic/modules/Accounts/dashboards/NewAccounts.tpl
@@ -2,7 +2,9 @@
 <div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">
@@ -32,7 +34,7 @@
 					</span>
 				</div>
 				<input type="text" name="time" title="{\App\Language::translate('LBL_CHOOSE_DATE')}" class="dateRangeField widgetFilter form-control text-center" value="{implode(',',$DTIME)}" />
-			</div>	
+			</div>
 		</div>
 		<div class="col-sm-6">
 			{include file=\App\Layout::getTemplatePath('dashboards/SelectAccessibleTemplate.tpl', $MODULE_NAME)}

--- a/layouts/basic/modules/Assets/dashboards/ExpiringSoldProducts.tpl
+++ b/layouts/basic/modules/Assets/dashboards/ExpiringSoldProducts.tpl
@@ -1,27 +1,21 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{if \App\Privilege::isPermitted($MODULE_NAME, 'CreateView')}
-					<a class="btn btn-light btn-sm" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('{$MODULE_NAME}'); return false;">
-						<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-					</a>
-				{/if}
-				<a class="btn btn-light btn-sm" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
-					<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+			{if \App\Privilege::isPermitted($MODULE_NAME, 'CreateView')}
+				<a class="btn btn-light btn-sm" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('{$MODULE_NAME}'); return false;">
+					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
 				</a>
-				{if !$WIDGET->isDefault()}
-					<a class="btn btn-light btn-sm" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
-						<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
-					</a>
-				{/if}
-			</div>
+			{/if}
+			<a class="btn btn-light btn-sm" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
+				<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+			</a>
+			{if !$WIDGET->isDefault()}
+				<a class="btn btn-light btn-sm" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
+					<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
+				</a>
+			{/if}
 		</div>
 	</div>
 	<hr class="widgetHr"/>

--- a/layouts/basic/modules/Assets/dashboards/ExpiringSoldProducts.tpl
+++ b/layouts/basic/modules/Assets/dashboards/ExpiringSoldProducts.tpl
@@ -1,8 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
-		<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+		<div class="d-inline-flex">
 			{if \App\Privilege::isPermitted($MODULE_NAME, 'CreateView')}
 				<a class="btn btn-light btn-sm" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('{$MODULE_NAME}'); return false;">
 					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>

--- a/layouts/basic/modules/Assets/dashboards/ExpiringSoldProducts.tpl
+++ b/layouts/basic/modules/Assets/dashboards/ExpiringSoldProducts.tpl
@@ -2,8 +2,8 @@
 <div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6"
-				 title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><b>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</b>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
 			</h5>
 		</div>
 		<div class="col-md-4">

--- a/layouts/basic/modules/Calendar/RelatedList.tpl
+++ b/layouts/basic/modules/Calendar/RelatedList.tpl
@@ -32,12 +32,12 @@
 									{if $RELATEDLIST_VIEW->get('linkicon') neq ''}
 										{assign var=BTN_ICON value=$RELATEDLIST_VIEW->get('linkicon')}
 									{/if}
-								{/if} 
+								{/if}
 							{/foreach}
 							<button class="btn btn-light dropdown-toggle relatedViewBtn" data-toggle="dropdown">
 								{if $BTN_ICON}
 									<span class="{$BTN_ICON}"></span>
-								{else}	
+								{else}
 									<span class="fas fa-list"></span>
 								{/if}
 								&nbsp;

--- a/layouts/basic/modules/FInvoice/dashboards/SummationByMonths.tpl
+++ b/layouts/basic/modules/FInvoice/dashboards/SummationByMonths.tpl
@@ -43,7 +43,7 @@ YetiForce_Bar_Widget_Js('YetiForce_SummationByMonths_Widget_Js',{}, {
 });
 </script>
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/FInvoice/dashboards/SummationByMonths.tpl
+++ b/layouts/basic/modules/FInvoice/dashboards/SummationByMonths.tpl
@@ -43,17 +43,9 @@ YetiForce_Bar_Widget_Js('YetiForce_SummationByMonths_Widget_Js',{}, {
 });
 </script>
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/FInvoice/dashboards/SummationByMonths.tpl
+++ b/layouts/basic/modules/FInvoice/dashboards/SummationByMonths.tpl
@@ -46,7 +46,7 @@ YetiForce_Bar_Widget_Js('YetiForce_SummationByMonths_Widget_Js',{}, {
 	<div class="row">
 		<div class="col-md-8">
 			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
 			</h5>
 		</div>
 		<div class="col-md-4">

--- a/layouts/basic/modules/FInvoice/dashboards/SummationByUser.tpl
+++ b/layouts/basic/modules/FInvoice/dashboards/SummationByUser.tpl
@@ -15,7 +15,7 @@
 	});
 </script>
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/FInvoice/dashboards/SummationByUser.tpl
+++ b/layouts/basic/modules/FInvoice/dashboards/SummationByUser.tpl
@@ -18,7 +18,7 @@
 	<div class="row">
 		<div class="col-md-8">
 			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
 			</h5>
 		</div>
 		<div class="col-md-4">

--- a/layouts/basic/modules/FInvoice/dashboards/SummationByUser.tpl
+++ b/layouts/basic/modules/FInvoice/dashboards/SummationByUser.tpl
@@ -15,17 +15,9 @@
 	});
 </script>
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByPriority.tpl
+++ b/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByPriority.tpl
@@ -1,17 +1,9 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row" >

--- a/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByPriority.tpl
+++ b/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByPriority.tpl
@@ -3,7 +3,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByPriority.tpl
+++ b/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByPriority.tpl
@@ -1,7 +1,7 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByUser.tpl
+++ b/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByUser.tpl
@@ -1,17 +1,9 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row">

--- a/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByUser.tpl
+++ b/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByUser.tpl
@@ -3,7 +3,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByUser.tpl
+++ b/layouts/basic/modules/HelpDesk/dashboards/ClosedTicketsByUser.tpl
@@ -1,7 +1,7 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/Leads/dashboards/LeadsByIndustry.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByIndustry.tpl
@@ -20,7 +20,7 @@
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Leads/dashboards/LeadsByIndustry.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByIndustry.tpl
@@ -20,17 +20,9 @@
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/Leads/dashboards/LeadsByIndustry.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByIndustry.tpl
@@ -22,7 +22,9 @@
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Leads/dashboards/LeadsBySource.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsBySource.tpl
@@ -11,17 +11,9 @@
 -->*}
 <div class="dashboardWidgetHeader">
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row">

--- a/layouts/basic/modules/Leads/dashboards/LeadsBySource.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsBySource.tpl
@@ -13,7 +13,9 @@
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Leads/dashboards/LeadsBySource.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsBySource.tpl
@@ -11,7 +11,7 @@
 -->*}
 <div class="dashboardWidgetHeader">
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Leads/dashboards/LeadsByStatus.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByStatus.tpl
@@ -20,7 +20,7 @@
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Leads/dashboards/LeadsByStatus.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByStatus.tpl
@@ -20,17 +20,9 @@
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row">

--- a/layouts/basic/modules/Leads/dashboards/LeadsByStatus.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByStatus.tpl
@@ -22,7 +22,9 @@
 	{assign var=WIDGET_WIDTH value=$WIDGET->getWidth()}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Leads/dashboards/LeadsByStatusConverted.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByStatusConverted.tpl
@@ -19,17 +19,9 @@
 	{foreach key=index item=jsModel from=$SCRIPTS}
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/Leads/dashboards/LeadsByStatusConverted.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByStatusConverted.tpl
@@ -21,7 +21,9 @@
 	{/foreach}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">
@@ -33,7 +35,7 @@
 	<div class="row" >
 		<div class="col-sm-6">
 			<div class="input-group input-group-sm">
-				<div class=" input-group-prepend">	
+				<div class=" input-group-prepend">
 					<span class="input-group-text u-cursor-pointer js-date__btn" data-js="click">
 						<span class="fas fa-calendar-alt" title="{\App\Language::translate('Created Time', $MODULE_NAME)} &nbsp; {\App\Language::translate('LBL_BETWEEN', $MODULE_NAME)}"></span>
 					</span>

--- a/layouts/basic/modules/Leads/dashboards/LeadsByStatusConverted.tpl
+++ b/layouts/basic/modules/Leads/dashboards/LeadsByStatusConverted.tpl
@@ -19,7 +19,7 @@
 	{foreach key=index item=jsModel from=$SCRIPTS}
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Notification/dashboards/Notifications.tpl
+++ b/layouts/basic/modules/Notification/dashboards/Notifications.tpl
@@ -1,17 +1,9 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), 'Home')}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) TITLE=App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row justify-content-end">

--- a/layouts/basic/modules/Notification/dashboards/Notifications.tpl
+++ b/layouts/basic/modules/Notification/dashboards/Notifications.tpl
@@ -1,7 +1,7 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) TITLE=App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/Notification/dashboards/Notifications.tpl
+++ b/layouts/basic/modules/Notification/dashboards/Notifications.tpl
@@ -3,7 +3,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle u-text-ellipsis h6" title="{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}"><strong>{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), 'Home')}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/Notification/dashboards/NotificationsBySenderRecipient.tpl
+++ b/layouts/basic/modules/Notification/dashboards/NotificationsBySenderRecipient.tpl
@@ -3,7 +3,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{\App\Language::translate($WIDGET->getTitle(), 'Home')}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), 'Home')}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), 'Home')}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/Notification/dashboards/NotificationsBySenderRecipient.tpl
+++ b/layouts/basic/modules/Notification/dashboards/NotificationsBySenderRecipient.tpl
@@ -1,17 +1,9 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), 'Home')}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) TITLE=App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row" >

--- a/layouts/basic/modules/Notification/dashboards/NotificationsBySenderRecipient.tpl
+++ b/layouts/basic/modules/Notification/dashboards/NotificationsBySenderRecipient.tpl
@@ -1,7 +1,7 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) TITLE=App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'Home'))}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/OSSMailView/dashboards/Graf.tpl
+++ b/layouts/basic/modules/OSSMailView/dashboards/Graf.tpl
@@ -86,7 +86,7 @@
 		<tbody>
 			<tr>
 				{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
-				<td class="col-md-auto order-1 order-md-2 text-center text-md-left">
+				<td class="d-inline-flex">
 					<div>
 						<select class="widgetFilter owner" name="owner" style='width:70px;margin-bottom:0px'>
 							<option value="{$CURRENTUSER->getId()}" >{\App\Language::translate('LBL_MINE')}</option>

--- a/layouts/basic/modules/OSSMailView/dashboards/Graf.tpl
+++ b/layouts/basic/modules/OSSMailView/dashboards/Graf.tpl
@@ -5,7 +5,7 @@
 * Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied.
 * See the License for the specific language governing rights and limitations under the License.
 * The Original Code is YetiForce.
-* The Initial Developer of the Original Code is YetiForce. Portions created by YetiForce are Copyright (C) www.yetiforce.com. 
+* The Initial Developer of the Original Code is YetiForce. Portions created by YetiForce are Copyright (C) www.yetiforce.com.
 * All Rights Reserved.
 *************************************************************************************************************************************/
 -->*}
@@ -86,7 +86,9 @@
 		<tbody>
 			<tr>
 				<td class="col-md-8">
-					<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><b>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</b></h5>
+					<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+						<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+					</h5>
 				</td>
 				<td class="col-md-2">
 					<div>

--- a/layouts/basic/modules/OSSMailView/dashboards/Graf.tpl
+++ b/layouts/basic/modules/OSSMailView/dashboards/Graf.tpl
@@ -85,12 +85,8 @@
 	<table width="100%" cellspacing="0" cellpadding="0">
 		<tbody>
 			<tr>
-				<td class="col-md-8">
-					<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-						<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-					</h5>
-				</td>
-				<td class="col-md-2">
+				{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
+				<td class="col-md-auto order-1 order-md-2 text-center text-md-left">
 					<div>
 						<select class="widgetFilter owner" name="owner" style='width:70px;margin-bottom:0px'>
 							<option value="{$CURRENTUSER->getId()}" >{\App\Language::translate('LBL_MINE')}</option>

--- a/layouts/basic/modules/OSSTimeControl/dashboards/AllTimeControl.tpl
+++ b/layouts/basic/modules/OSSTimeControl/dashboards/AllTimeControl.tpl
@@ -1,8 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
-		<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+		<div class="d-inline-flex">
 			{if \App\Privilege::isPermitted('OSSTimeControl', 'CreateView')}
 				<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('OSSTimeControl'); return false;">
 					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>

--- a/layouts/basic/modules/OSSTimeControl/dashboards/AllTimeControl.tpl
+++ b/layouts/basic/modules/OSSTimeControl/dashboards/AllTimeControl.tpl
@@ -2,7 +2,9 @@
 <div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">
@@ -32,7 +34,7 @@
 					</span>
 				</div>
 				<input type="text" name="time" title="{\App\Language::translate('LBL_CHOOSE_DATE')}" class="dateRangeField widgetFilter form-control text-center" value="{implode(',',$DTIME)}" />
-			</div>	
+			</div>
 		</div>
 		<div class="col-sm-6">
 			{include file=\App\Layout::getTemplatePath('dashboards/SelectAccessibleTemplate.tpl', $MODULE_NAME)}

--- a/layouts/basic/modules/OSSTimeControl/dashboards/AllTimeControl.tpl
+++ b/layouts/basic/modules/OSSTimeControl/dashboards/AllTimeControl.tpl
@@ -1,27 +1,21 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{if \App\Privilege::isPermitted('OSSTimeControl', 'CreateView')}
-					<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('OSSTimeControl'); return false;">
-						<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-					</a>
-				{/if}
-				<a class="btn btn-sm btn-light" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
-					<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
+		<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+			{if \App\Privilege::isPermitted('OSSTimeControl', 'CreateView')}
+				<a class="btn btn-sm btn-light" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('OSSTimeControl'); return false;">
+					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
 				</a>
-				{if !$WIDGET->isDefault()}
-					<a class="btn btn-sm btn-light" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
-						<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
-					</a>
-				{/if}
-			</div>
+			{/if}
+			<a class="btn btn-sm btn-light" role="button" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
+				<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+			</a>
+			{if !$WIDGET->isDefault()}
+				<a class="btn btn-sm btn-light" role="button" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
+					<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
+				</a>
+			{/if}
 		</div>
 	</div>
 	<hr class="widgetHr" />

--- a/layouts/basic/modules/OSSTimeControl/dashboards/TimeControl.tpl
+++ b/layouts/basic/modules/OSSTimeControl/dashboards/TimeControl.tpl
@@ -49,7 +49,9 @@
 	{/foreach}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/OSSTimeControl/dashboards/TimeControl.tpl
+++ b/layouts/basic/modules/OSSTimeControl/dashboards/TimeControl.tpl
@@ -47,28 +47,22 @@
 	{foreach key=index item=jsModel from=$SCRIPTS}
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{if \App\Privilege::isPermitted('OSSTimeControl', 'CreateView')}
-					<a class="btn btn-sm btn-light" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('OSSTimeControl'); return false;">
-						<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-					</a>
-				{/if}
-				<a class="btn btn-sm btn-light" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
-					<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
+		<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+			{if \App\Privilege::isPermitted('OSSTimeControl', 'CreateView')}
+				<a class="btn btn-sm btn-light" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('OSSTimeControl'); return false;">
+					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
 				</a>
-				{if !$WIDGET->isDefault()}
-					<a class="btn btn-sm btn-light" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
-						<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
-					</a>
-				{/if}
-			</div>
+			{/if}
+			<a class="btn btn-sm btn-light" href="javascript:void(0);" name="drefresh" data-url="{$WIDGET->getUrl()}&linkid={$WIDGET->get('linkid')}&content=data">
+				<span class="fas fa-sync-alt" title="{\App\Language::translate('LBL_REFRESH')}"></span>
+			</a>
+			{if !$WIDGET->isDefault()}
+				<a class="btn btn-sm btn-light" name="dclose" class="widget" data-url="{$WIDGET->getDeleteUrl()}">
+					<span class="fas fa-times" title="{\App\Language::translate('LBL_CLOSE')}"></span>
+				</a>
+			{/if}
 		</div>
 	</div>
 	<hr class="widgetHr" />

--- a/layouts/basic/modules/OSSTimeControl/dashboards/TimeControl.tpl
+++ b/layouts/basic/modules/OSSTimeControl/dashboards/TimeControl.tpl
@@ -47,9 +47,9 @@
 	{foreach key=index item=jsModel from=$SCRIPTS}
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
-		<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+		<div class="d-inline-flex">
 			{if \App\Privilege::isPermitted('OSSTimeControl', 'CreateView')}
 				<a class="btn btn-sm btn-light" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('OSSTimeControl'); return false;">
 					<span class="fas fa-plus" title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>

--- a/layouts/basic/modules/SSalesProcesses/dashboards/EstimatedValueByStatus.tpl
+++ b/layouts/basic/modules/SSalesProcesses/dashboards/EstimatedValueByStatus.tpl
@@ -1,6 +1,6 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/SSalesProcesses/dashboards/EstimatedValueByStatus.tpl
+++ b/layouts/basic/modules/SSalesProcesses/dashboards/EstimatedValueByStatus.tpl
@@ -1,16 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/SSalesProcesses/dashboards/EstimatedValueByStatus.tpl
+++ b/layouts/basic/modules/SSalesProcesses/dashboards/EstimatedValueByStatus.tpl
@@ -1,8 +1,10 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
-<div class="dashboardWidgetHeader">	
+<div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/SSalesProcesses/dashboards/TeamsEstimatedSales.tpl
+++ b/layouts/basic/modules/SSalesProcesses/dashboards/TeamsEstimatedSales.tpl
@@ -1,6 +1,6 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/SSalesProcesses/dashboards/TeamsEstimatedSales.tpl
+++ b/layouts/basic/modules/SSalesProcesses/dashboards/TeamsEstimatedSales.tpl
@@ -1,16 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 <div class="dashboardWidgetHeader">
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/SSalesProcesses/dashboards/TeamsEstimatedSales.tpl
+++ b/layouts/basic/modules/SSalesProcesses/dashboards/TeamsEstimatedSales.tpl
@@ -1,8 +1,10 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
-<div class="dashboardWidgetHeader">	
+<div class="dashboardWidgetHeader">
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">
@@ -18,13 +20,13 @@
 					<span class="input-group-text u-cursor-pointer js-date__btn" data-js="click">
 						<span class="fas fa-calendar-alt"></span>
 					</span>
-				</div>	
+				</div>
 				<input type="text" name="time" title="{\App\Language::translate('LBL_CHOOSE_DATE')}" class="dateRangeField widgetFilter form-control text-center" value="{$DTIME}">
 				<span class="input-group-addon checkbox-addon">
 					<input name="compare" class="widgetFilter" type="checkbox" {if $COMPARE}checked{/if} title="{\App\Language::translate('LBL_COMPARE_TO_LAST_PERIOD', $MODULE_NAME)}">
 					<a href="#" class="js-popover-tooltip" data-js="popover" title="" data-placement="top" data-content="{\App\Language::translate('LBL_COMPARE_TO_LAST_PERIOD', $MODULE_NAME)}"><span class="fas fa-info-circle"></span></a>
 				</span>
-			</div>	
+			</div>
 		</div>
 	</div>
 </div>

--- a/layouts/basic/modules/Vtiger/dashboards/Calendar.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/Calendar.tpl
@@ -5,17 +5,15 @@
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="tpl-dashboards-Calendar">
 		<div class="dashboardWidgetHeader">
-			<div class="row no-gutters justify-content-between">
+			<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 				{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
-				<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
-					<div>
-						{if \App\Privilege::isPermitted('Calendar', 'CreateView')}
-							<a class="btn btn-light btn-sm" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Calendar'); return false;">
-								<span class='fas fa-plus' title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-							</a>
-						{/if}
-						{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-					</div>
+				<div class="d-inline-flex">
+					{if \App\Privilege::isPermitted('Calendar', 'CreateView')}
+						<a class="btn btn-light btn-sm" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Calendar'); return false;">
+							<span class='fas fa-plus' title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
+						</a>
+					{/if}
+					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
 				</div>
 			</div>
 			<hr class="widgetHr"/>

--- a/layouts/basic/modules/Vtiger/dashboards/Calendar.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/Calendar.tpl
@@ -5,14 +5,10 @@
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="tpl-dashboards-Calendar">
 		<div class="dashboardWidgetHeader">
-			<div class="row">
-				<div class="col-sm-8">
-					<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-						<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-					</h5>
-				</div>
-				<div class="col-sm-4">
-					<div class="box float-right">
+			<div class="row no-gutters justify-content-between">
+				{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+				<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+					<div>
 						{if \App\Privilege::isPermitted('Calendar', 'CreateView')}
 							<a class="btn btn-light btn-sm" role="button" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Calendar'); return false;">
 								<span class='fas fa-plus' title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>

--- a/layouts/basic/modules/Vtiger/dashboards/Calendar.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/Calendar.tpl
@@ -7,9 +7,9 @@
 		<div class="dashboardWidgetHeader">
 			<div class="row">
 				<div class="col-sm-8">
-					<h5 class="dashboardTitle h6"
-						 title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-						<strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+					<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+						<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+					</h5>
 				</div>
 				<div class="col-sm-4">
 					<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/CalendarActivities.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/CalendarActivities.tpl
@@ -16,7 +16,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-6">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-6">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/CalendarActivities.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/CalendarActivities.tpl
@@ -14,26 +14,24 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-6"}
-			<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
-				<div>
-					{if \App\Privilege::isPermitted('Calendar', 'CreateView')}
-						<a class="btn btn-sm btn-light" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Calendar');
-								return false;" aria-label="{\App\Language::translate('LBL_ADD_RECORD')}" href="#" role="button">
-							<span class='fas fa-plus' title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
-						</a>
-					{/if}&nbsp;
-					<button class="btn btn-light btn-sm changeRecordSort" title="{\App\Language::translate('LBL_SORT_DESCENDING', $MODULE_NAME)}" data-sort="{if $DATA['sortorder'] eq 'desc'}asc{else}desc{/if}" data-asc="{\App\Language::translate('LBL_SORT_ASCENDING', $MODULE_NAME)}" data-desc="{\App\Language::translate('LBL_SORT_DESCENDING', $MODULE_NAME)}">
-						<span class="fas fa-sort-amount-down" ></span>
+			<div class="d-inline-flex">
+				{if \App\Privilege::isPermitted('Calendar', 'CreateView')}
+					<a class="btn btn-sm btn-light" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Calendar');
+							return false;" aria-label="{\App\Language::translate('LBL_ADD_RECORD')}" href="#" role="button">
+						<span class='fas fa-plus' title="{\App\Language::translate('LBL_ADD_RECORD')}"></span>
+					</a>
+				{/if}&nbsp;
+				<button class="btn btn-light btn-sm changeRecordSort" title="{\App\Language::translate('LBL_SORT_DESCENDING', $MODULE_NAME)}" data-sort="{if $DATA['sortorder'] eq 'desc'}asc{else}desc{/if}" data-asc="{\App\Language::translate('LBL_SORT_ASCENDING', $MODULE_NAME)}" data-desc="{\App\Language::translate('LBL_SORT_DESCENDING', $MODULE_NAME)}">
+					<span class="fas fa-sort-amount-down" ></span>
+				</button>
+				{if $LISTVIEWLINKS}&nbsp;
+					<button class="btn btn-light btn-sm goToListView" title="{\App\Language::translate('LBL_GO_TO_RECORDS_LIST', $MODULE_NAME)}" >
+						<span class="fas fa-th-list"></span>
 					</button>
-					{if $LISTVIEWLINKS}&nbsp;
-						<button class="btn btn-light btn-sm goToListView" title="{\App\Language::translate('LBL_GO_TO_RECORDS_LIST', $MODULE_NAME)}" >
-							<span class="fas fa-th-list"></span>
-						</button>
-					{/if}&nbsp;
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
+				{/if}&nbsp;
+				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
 			</div>
 		</div>
 		<hr class="widgetHr" />

--- a/layouts/basic/modules/Vtiger/dashboards/CalendarActivities.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/CalendarActivities.tpl
@@ -14,14 +14,10 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-6">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-6">
-				<div class="box float-right">
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-6"}
+			<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+				<div>
 					{if \App\Privilege::isPermitted('Calendar', 'CreateView')}
 						<a class="btn btn-sm btn-light" onclick="Vtiger_Header_Js.getInstance().quickCreateModule('Calendar');
 								return false;" aria-label="{\App\Language::translate('LBL_ADD_RECORD')}" href="#" role="button">

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="col-md-6">
 				<h5 class="dashboardTitle h6">
-					<strong class="d-block u-text-ellipsis--no-hover js-popover-tooltip" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-placement="top" data-toggle="tooltip" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+					<strong class="d-block u-text-ellipsis--no-hover js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
 			</div>
 			<div class="col-md-6">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -3,8 +3,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-6">
-				<h5 class="dashboardTitle h6">
-					<strong class="d-block u-text-ellipsis--no-hover js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-6">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -1,9 +1,9 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
-			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-8"}
-			<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-6"}
+			<div class="d-inline-flex">
 				<button class="btn btn-sm btn-light downloadWidget hidden" data-widgetid="{$CHART_MODEL->get('widgetid')}" title="{\App\Language::translate('LBL_WIDGET_DOWNLOAD','Home')}">
 					<span class="far fa-arrow-alt-circle-down"></span>
 				</button>&nbsp;

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -3,7 +3,7 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-6">
-				<h5 class="dashboardTitle h6 u-text-ellipsis--no-hover js-tooltip" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-placement="right" data-toggle="tooltip" data-js="tooltip">
+				<h5 class="dashboardTitle h6 u-text-ellipsis--no-hover js-popover-tooltip" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-placement="right" data-toggle="tooltip" data-js="tooltip">
 					<strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
 			</div>
 			<div class="col-md-6">

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -1,37 +1,24 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-6">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-6">
-				<div class="box float-right">
-					<button class="btn btn-sm btn-light downloadWidget hidden"
-							data-widgetid="{$CHART_MODEL->get('widgetid')}"
-							title="{\App\Language::translate('LBL_WIDGET_DOWNLOAD','Home')}">
-						<span class="far fa-arrow-alt-circle-down"></span>
-					</button>&nbsp;
-					<button class="btn btn-sm btn-light printWidget hidden"
-							data-widgetid="{$CHART_MODEL->get('widgetid')}"
-							title="{\App\Language::translate('LBL_WIDGET_PRINT','Home')}">
-						<span class="fas fa-print"></span>
-					</button>&nbsp;
-					{if count($CHART_MODEL->getFilterIds())<=1}
-						<button class="btn btn-sm btn-light recordCount"
-								data-url="{\App\Purifier::encodeHtml($CHART_MODEL->getTotalCountURL())}"
-								title="{\App\Language::translate('LBL_WIDGET_FILTER_TOTAL_COUNT_INFO')}">
-							<span class="fas fa-signal" aria-hidden="false"></span>
-							<a class="d-none" aria-hidden="true"
-							   href="{\App\Purifier::encodeHtml($CHART_MODEL->getListViewURL())}">
-								<span class="count badge badge-secondary"></span>
-							</a>
-						</button>
-					{/if}
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-8"}
+			<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+				<button class="btn btn-sm btn-light downloadWidget hidden" data-widgetid="{$CHART_MODEL->get('widgetid')}" title="{\App\Language::translate('LBL_WIDGET_DOWNLOAD','Home')}">
+					<span class="far fa-arrow-alt-circle-down"></span>
+				</button>&nbsp;
+				<button class="btn btn-sm btn-light printWidget hidden" data-widgetid="{$CHART_MODEL->get('widgetid')}" title="{\App\Language::translate('LBL_WIDGET_PRINT','Home')}">
+					<span class="fas fa-print"></span>
+				</button>&nbsp;
+				{if count($CHART_MODEL->getFilterIds())<=1}
+					<button class="btn btn-sm btn-light recordCount" data-url="{\App\Purifier::encodeHtml($CHART_MODEL->getTotalCountURL())}" title="{\App\Language::translate('LBL_WIDGET_FILTER_TOTAL_COUNT_INFO')}">
+						<span class="fas fa-signal" aria-hidden="false"></span>
+						<a class="d-none" aria-hidden="true" href="{\App\Purifier::encodeHtml($CHART_MODEL->getListViewURL())}">
+							<span class="count badge badge-secondary"></span>
+						</a>
+					</button>
+				{/if}
+				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
 			</div>
 		</div>
 		{assign var="WIDGET_DATA" value=$WIDGET->getArray('data')}

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -2,12 +2,11 @@
 {strip}
 	<div class="dashboardWidgetHeader">
 		<div class="row">
-			<div class="col-md-7">
-				<h5 class="dashboardTitle h6"
-					 title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+			<div class="col-md-6">
+				<h5 class="dashboardTitle h6 u-text-ellipsis--no-hover js-tooltip" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-placement="right" data-toggle="tooltip" data-js="tooltip">
 					<strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
 			</div>
-			<div class="col-md-5">
+			<div class="col-md-6">
 				<div class="box float-right">
 					<button class="btn btn-sm btn-light downloadWidget hidden"
 							data-widgetid="{$CHART_MODEL->get('widgetid')}"

--- a/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ChartFilterHeader.tpl
@@ -3,8 +3,8 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-6">
-				<h5 class="dashboardTitle h6 u-text-ellipsis--no-hover js-popover-tooltip" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-placement="right" data-toggle="tooltip" data-js="tooltip">
-					<strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6">
+					<strong class="d-block u-text-ellipsis--no-hover js-popover-tooltip" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-placement="top" data-toggle="tooltip" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
 			</div>
 			<div class="col-md-6">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/CreatedNotMineActivities.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/CreatedNotMineActivities.tpl
@@ -4,15 +4,9 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="d-flex flex-nowrap" >

--- a/layouts/basic/modules/Vtiger/dashboards/CreatedNotMineActivities.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/CreatedNotMineActivities.tpl
@@ -4,7 +4,7 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/Vtiger/dashboards/History.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/History.tpl
@@ -11,7 +11,7 @@
 -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/Vtiger/dashboards/History.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/History.tpl
@@ -11,17 +11,9 @@
 -->*}
 {strip}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row justify-content-end" >

--- a/layouts/basic/modules/Vtiger/dashboards/History.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/History.tpl
@@ -13,7 +13,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle u-text-ellipsis h6" title="{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}"><strong>{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/ListUpdatedRecord.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ListUpdatedRecord.tpl
@@ -11,17 +11,9 @@
 -->*}
 {strip}
 	<div class="tpl-Vtiger-dashboards-ListUpdatedRecord dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row justify-content-end m-0">

--- a/layouts/basic/modules/Vtiger/dashboards/ListUpdatedRecord.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ListUpdatedRecord.tpl
@@ -13,7 +13,9 @@
 	<div class="tpl-Vtiger-dashboards-ListUpdatedRecord dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),$MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/ListUpdatedRecord.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ListUpdatedRecord.tpl
@@ -11,7 +11,7 @@
 -->*}
 {strip}
 	<div class="tpl-Vtiger-dashboards-ListUpdatedRecord dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/Vtiger/dashboards/MailsList.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/MailsList.tpl
@@ -9,7 +9,9 @@
 		{/foreach}
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle pb-2 h6" title="{\App\Language::translate($WIDGET->getTitle(), 'OSSMail')}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(),'OSSMail')}</strong></h5>
+				<h5 class="dashboardTitle pb-2 h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'OSSMail'))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), ))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">
@@ -30,7 +32,7 @@
 							<span class="fas fa-envelope"></span>
 						</span>
 					</div>
-					<div class="select2Wrapper">			
+					<div class="select2Wrapper">
 						<select class="mailUserList form-control select2" aria-label="Small" aria-describedby="inputGroup-sizing-sm" id="mailUserList" title="{\App\Language::translate('LBL_MAIL_USERS_LIST')}" name="type">
 							{if count($ACCOUNTSLIST) eq 0}
 								<option value="-">{\App\Language::translate('--None--', $MODULE_NAME)}</option>

--- a/layouts/basic/modules/Vtiger/dashboards/MailsList.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/MailsList.tpl
@@ -7,14 +7,10 @@
 		{foreach key=index item=jsModel from=$SCRIPTS}
 			<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 		{/foreach}
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle pb-2 h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), 'OSSMail'))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), ))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+			<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
+				<div>
 					{if !$WIDGET->isDefault()}
 						<a name="dclose" class="btn btn-sm btn-light widget" data-url="{$WIDGET->getDeleteUrl()}">
 							<span class="fas fa-times" hspace="2" border="0" align="absmiddle" title="{\App\Language::translate('LBL_CLOSE')}" alt="{\App\Language::translate('LBL_CLOSE')}"></span>

--- a/layouts/basic/modules/Vtiger/dashboards/MailsList.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/MailsList.tpl
@@ -7,16 +7,14 @@
 		{foreach key=index item=jsModel from=$SCRIPTS}
 			<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 		{/foreach}
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
-			<div class="ol-md-auto order-1 order-md-2 text-center text-md-left">
-				<div>
-					{if !$WIDGET->isDefault()}
-						<a name="dclose" class="btn btn-sm btn-light widget" data-url="{$WIDGET->getDeleteUrl()}">
-							<span class="fas fa-times" hspace="2" border="0" align="absmiddle" title="{\App\Language::translate('LBL_CLOSE')}" alt="{\App\Language::translate('LBL_CLOSE')}"></span>
-						</a>
-					{/if}
-				</div>
+			<div class="d-inline-flex">
+				{if !$WIDGET->isDefault()}
+					<a name="dclose" class="btn btn-sm btn-light widget" data-url="{$WIDGET->getDeleteUrl()}">
+						<span class="fas fa-times" hspace="2" border="0" align="absmiddle" title="{\App\Language::translate('LBL_CLOSE')}" alt="{\App\Language::translate('LBL_CLOSE')}"></span>
+					</a>
+				{/if}
 			</div>
 		</div>
 		<hr class="widgetHr" />

--- a/layouts/basic/modules/Vtiger/dashboards/MiniList.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/MiniList.tpl
@@ -12,17 +12,9 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$USER_MODEL->getId()}
 	<div class="tpl-dashboards-Minilist dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row" >

--- a/layouts/basic/modules/Vtiger/dashboards/MiniList.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/MiniList.tpl
@@ -12,8 +12,8 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$USER_MODEL->getId()}
 	<div class="tpl-dashboards-Minilist dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
-			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME) CLASSNAME="col-md-10"}
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />

--- a/layouts/basic/modules/Vtiger/dashboards/MiniList.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/MiniList.tpl
@@ -14,7 +14,9 @@
 	<div class="tpl-dashboards-Minilist dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/ProductsSoldToRenew.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ProductsSoldToRenew.tpl
@@ -4,17 +4,9 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="dashboardWidgetHeader">
-		<div class="row">
-			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-				</h5>
-			</div>
-			<div class="col-md-4">
-				<div class="box float-right">
-					{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-				</div>
-			</div>
+		<div class="row no-gutters justify-content-between">
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>
 		<hr class="widgetHr" />
 		<div class="row" >

--- a/layouts/basic/modules/Vtiger/dashboards/ProductsSoldToRenew.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ProductsSoldToRenew.tpl
@@ -4,7 +4,7 @@
 	{assign var=ACCESSIBLE_GROUPS value=\App\Fields\Owner::getInstance()->getAccessibleGroups()}
 	{assign var=CURRENTUSERID value=$CURRENTUSER->getId()}
 	<div class="dashboardWidgetHeader">
-		<div class="row no-gutters justify-content-between">
+		<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 			{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 		</div>

--- a/layouts/basic/modules/Vtiger/dashboards/ProductsSoldToRenew.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/ProductsSoldToRenew.tpl
@@ -6,7 +6,9 @@
 	<div class="dashboardWidgetHeader">
 		<div class="row">
 			<div class="col-md-8">
-				<h5 class="dashboardTitle h6" title="{\App\Language::translate($WIDGET->getTitle())}"><strong>{\App\Language::translate($WIDGET->getTitle())}</strong></h5>
+				<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+					<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+				</h5>
 			</div>
 			<div class="col-md-4">
 				<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeadeAccessible.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeadeAccessible.tpl
@@ -1,16 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 	<hr class="widgetHr" />
 	<div class="row" >

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeadeAccessible.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeadeAccessible.tpl
@@ -2,7 +2,9 @@
 {strip}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeadeAccessible.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeadeAccessible.tpl
@@ -1,6 +1,6 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeader.tpl
@@ -16,7 +16,7 @@
 	{foreach key=index item=jsModel from=$SCRIPTS}
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
-	<div class="row no-gutters justify-content-between">
+	<div class="d-flex flex-row flex-nowrap no-gutters justify-content-between">
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
 		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeader.tpl
@@ -18,7 +18,9 @@
 	{/foreach}
 	<div class="row">
 		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}"><strong>&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong></h5>
+			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
+				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
+			</h5>
 		</div>
 		<div class="col-md-4">
 			<div class="box float-right">

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeader.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeader.tpl
@@ -16,16 +16,8 @@
 	{foreach key=index item=jsModel from=$SCRIPTS}
 		<script type="{$jsModel->getType()}" src="{$jsModel->getSrc()}"></script>
 	{/foreach}
-	<div class="row">
-		<div class="col-md-8">
-			<h5 class="dashboardTitle h6" title="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}">
-				<strong class="d-block js-popover-tooltip--ellipsis" data-content="{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}" data-toggle="popover" data-js="tooltip">&nbsp;&nbsp;{\App\Language::translate($WIDGET->getTitle(), $MODULE_NAME)}</strong>
-			</h5>
-		</div>
-		<div class="col-md-4">
-			<div class="box float-right">
-				{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-			</div>
-		</div>
+	<div class="row no-gutters justify-content-between">
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderTitle.tpl', $MODULE_NAME)}
+		{include file=\App\Layout::getTemplatePath('dashboards/WidgetHeaderButtons.tpl', $MODULE_NAME)}
 	</div>
 {/strip}

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderButtons.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderButtons.tpl
@@ -1,6 +1,4 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
-<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
-	<div class="">
-		{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
-	</div>
+<div class="d-inline-flex">
+	{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
 </div>

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderButtons.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderButtons.tpl
@@ -1,0 +1,6 @@
+{*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
+<div class="col-md-auto order-1 order-md-2 text-center text-md-left">
+	<div class="">
+		{include file=\App\Layout::getTemplatePath('dashboards/DashboardHeaderIcons.tpl', $MODULE_NAME)}
+	</div>
+</div>

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderTitle.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderTitle.tpl
@@ -1,6 +1,4 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
-<div class="col-md-8 {$CLASSNAME} order-2 order-md-1 text-center text-md-left">
-	<h5 class="h6 d-block p-1 m-0 js-popover-tooltip" data-ellipsis="true" data-content="{if !isset($TITLE)}{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}{else}{$TITLE}{/if}" data-toggle="popover" data-js="tooltip">
-		<strong>{if !isset($TITLE)}{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}{else}{$TITLE}{/if}</strong>
-	</h5>
-</div>
+<h5 class="h6 d-block p-1 m-0 js-popover-tooltip" data-ellipsis="true" data-content="{if !isset($TITLE)}{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}{else}{$TITLE}{/if}" data-toggle="popover" data-js="tooltip">
+	{if !isset($TITLE)}{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}{else}{$TITLE}{/if}
+</h5>

--- a/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderTitle.tpl
+++ b/layouts/basic/modules/Vtiger/dashboards/WidgetHeaderTitle.tpl
@@ -1,0 +1,6 @@
+{*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
+<div class="col-md-8 {$CLASSNAME} order-2 order-md-1 text-center text-md-left">
+	<h5 class="h6 d-block p-1 m-0 js-popover-tooltip" data-ellipsis="true" data-content="{if !isset($TITLE)}{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}{else}{$TITLE}{/if}" data-toggle="popover" data-js="tooltip">
+		<strong>{if !isset($TITLE)}{App\Purifier::encodeHtml(App\Language::translate($WIDGET->getTitle(), $MODULE_NAME))}{else}{$TITLE}{/if}</strong>
+	</h5>
+</div>

--- a/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
@@ -1339,7 +1339,6 @@ jQuery.Class('Vtiger_Widget_Js', {
 		this.registerFilterChangeEvent();
 		this.restrictContentDrag();
 		app.showPopoverElementView(this.getContainer().find('.js-popover-tooltip'));
-		app.showTooltipElementView(this.getContainer().find('.js-tooltip'));
 		this.registerWidgetSwitch();
 		this.registerChangeSorting();
 		this.registerLoadMore();

--- a/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
@@ -1339,6 +1339,7 @@ jQuery.Class('Vtiger_Widget_Js', {
 		this.registerFilterChangeEvent();
 		this.restrictContentDrag();
 		app.showPopoverElementView(this.getContainer().find('.js-popover-tooltip'));
+		app.showPopoverEllipsisView(this.getContainer().find('.js-popover-tooltip--ellipsis'));
 		this.registerWidgetSwitch();
 		this.registerChangeSorting();
 		this.registerLoadMore();

--- a/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
@@ -2299,6 +2299,7 @@ YetiForce_Widget_Js('YetiForce_Calendar_Widget_Js', {}, {
 		this.loadCalendarData(true);
 		this.registerChangeView();
 		this.registerFilterChangeEvent();
+		app.showPopoverElementView(this.getContainer().find('.js-popover-tooltip'));
 	},
 	refreshWidget: function () {
 		var thisInstance = this;
@@ -2614,6 +2615,7 @@ YetiForce_Widget_Js('YetiForce_MiniList_Widget_Js', {}, {
 		this.restrictContentDrag();
 		this.registerFilterChangeEvent();
 		this.registerRecordsCount();
+		app.showPopoverElementView(this.getContainer().find('.js-popover-tooltip'));
 	},
 	postRefreshWidget: function () {
 		this.registerRecordsCount();

--- a/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
@@ -1339,6 +1339,7 @@ jQuery.Class('Vtiger_Widget_Js', {
 		this.registerFilterChangeEvent();
 		this.restrictContentDrag();
 		app.showPopoverElementView(this.getContainer().find('.js-popover-tooltip'));
+		app.showTooltipElementView(this.getContainer().find('.js-tooltip'));
 		this.registerWidgetSwitch();
 		this.registerChangeSorting();
 		this.registerLoadMore();

--- a/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/dashboards/Widget.js
@@ -1339,7 +1339,6 @@ jQuery.Class('Vtiger_Widget_Js', {
 		this.registerFilterChangeEvent();
 		this.restrictContentDrag();
 		app.showPopoverElementView(this.getContainer().find('.js-popover-tooltip'));
-		app.showPopoverEllipsisView(this.getContainer().find('.js-popover-tooltip--ellipsis'));
 		this.registerWidgetSwitch();
 		this.registerChangeSorting();
 		this.registerLoadMore();

--- a/public_html/layouts/basic/styles/_Style.scss
+++ b/public_html/layouts/basic/styles/_Style.scss
@@ -2289,7 +2289,9 @@ span[name=existingImages] img {
 }
 
 .widgetHr {
-	margin-top: 0;
+	margin-top: 7px;
+  	border: none;
+  	border-top: 1px solid #ddd;
 }
 
 #groupsDetailContainer strong {
@@ -3029,7 +3031,7 @@ html, body, .o-base-container {
 }
 
 @media only screen and (max-width: 992px) {
-  
+
   .listViewActionsDiv .btn-toolbar, .editViewContainer .btn-toolbar, .widget_header .btn-toolbar {
 	margin-bottom: 5px;
   }

--- a/public_html/layouts/basic/styles/_Style.scss
+++ b/public_html/layouts/basic/styles/_Style.scss
@@ -2289,7 +2289,7 @@ span[name=existingImages] img {
 }
 
 .widgetHr {
-	margin-top: 7px;
+	margin-top: calculate-rem(7px);
   	border: none;
   	border-top: 1px solid #ddd;
 }

--- a/public_html/layouts/basic/styles/components/_Utilities.scss
+++ b/public_html/layouts/basic/styles/components/_Utilities.scss
@@ -37,7 +37,7 @@
 		}
 	}
 }
-.u-text-ellipsis--no-hover {
+.u-text-ellipsis--no-hover, .js-popover-tooltip--ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/public_html/layouts/basic/styles/components/_Utilities.scss
+++ b/public_html/layouts/basic/styles/components/_Utilities.scss
@@ -37,7 +37,7 @@
 		}
 	}
 }
-.u-text-ellipsis--no-hover, .js-popover-tooltip--ellipsis {
+.u-text-ellipsis--no-hover, .js-popover-tooltip[data-ellipsis="true"] {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/public_html/layouts/basic/styles/components/_Utilities.scss
+++ b/public_html/layouts/basic/styles/components/_Utilities.scss
@@ -37,11 +37,19 @@
 		}
 	}
 }
-.u-text-ellipsis--no-hover, .js-popover-tooltip[data-ellipsis="true"] {
+.u-text-ellipsis--no-hover, .js-popover-tooltip[data-ellipsis]{
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.u-text-ellipsis--not-active{
+  width: auto !important;
+  text-overflow: unset !important;
+  visibility: hidden !important;
+  overflow: visible !important;
+  display: inline-block !important
+}
+
 .u-text-underline {
 	text-decoration: underline;
 }

--- a/public_html/layouts/basic/styles/pages/_Dashboard.scss
+++ b/public_html/layouts/basic/styles/pages/_Dashboard.scss
@@ -83,7 +83,7 @@
 				border-bottom: 1px solid #ddd;
 				color: #444;
 				cursor: move;
-				padding: 5px;
+				padding: 7px 5px;
 
 				table {
 					height: 28px;

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -143,43 +143,24 @@ app = {
 		clone.remove();
 		return false;
 	},
-	showPopoverEllipsisView(elements, params) {
-		let currentParams = $.extend(true, {
-			trigger: 'hover',
-			placement: 'auto',
-			html: true,
-			template: '<div class="popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
-			container: 'body',
-			delay: {"show": 300, "hide": 100},
-		}, params);
-		elements.each(function (index, domElement) {
-			let element = $(domElement);
-			if(!app.isEllipsisActive(element)){
-				return;
-			}
-			let elementParams = $.extend(true, currentParams, element.data());
-			if (element.data('class')) {
-				elementParams.template = '<div class="popover ' + element.data('class') + '" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
-			}
-			if (element.hasClass('delay0')) {
-				elementParams.delay = {show: 0, hide: 0}
-			}
-			element.popover(elementParams);
-		});
-		return elements;
-	},
 	showPopoverElementView: function (selectElement, params = {}) {
-		let currentParams = $.extend(true, {
+		let defaultParams = {
 			trigger: 'manual',
 			placement: 'auto',
 			html: true,
 			template: '<div class="popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
 			container: 'body',
 			delay: {"show": 300, "hide": 100},
-		}, params);
+		};
 		selectElement.each(function (index, domElement) {
 			let element = $(domElement);
-			let elementParams = $.extend(true, currentParams, element.data());
+			if(element.data('ellipsis')){
+				defaultParams.trigger='hover';
+				if(!app.isEllipsisActive(element)){
+					return;
+				}
+			}
+			let elementParams = $.extend(true, defaultParams, params, element.data());
 			if (element.data('class')) {
 				elementParams.template = '<div class="popover ' + element.data('class') + '" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
 			}
@@ -1487,7 +1468,6 @@ app = {
 $(document).ready(function () {
 	App.Fields.Picklist.changeSelectElementView();
 	app.showPopoverElementView($('body').find('.js-popover-tooltip'));
-	app.showPopoverEllipsisView($('body').find('.js-popover-tooltip--ellipsis'));
 	app.registerSticky();
 	app.registerMoreContent($('body').find('button.moreBtn'));
 	app.registerModal();

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -134,8 +134,9 @@ app = {
 	isEllipsisActive(element) {
 		let clone = element
 			.clone()
-			.attr('style', 'width:auto;visibility:hidden;overflow:visible;display:inline !important') // we cannot use css because of !important
+			.attr('style', 'width:auto;text-overflow:unset;visibility:hidden;overflow:visible;display:inline-block !important') // we cannot use css because of !important
 			.appendTo('body');
+		console.log(clone.innerWidth(), element.innerWidth());
 		if (clone.width() > element.width()) {
 			clone.remove();
 			return true;

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -145,7 +145,7 @@ app = {
 	},
 	showPopoverEllipsisView(elements, params) {
 		let currentParams = $.extend(true, {
-			trigger: 'manual',
+			trigger: 'hover',
 			placement: 'auto',
 			html: true,
 			template: '<div class="popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
@@ -165,12 +165,6 @@ app = {
 				elementParams.delay = {show: 0, hide: 0}
 			}
 			element.popover(elementParams);
-			element.on("mouseenter", function(){
-				$(this).popover('show');
-			});
-			element.on("mouseleave", function () {
-				$(this).popover('hide');
-			});
 		});
 		return elements;
 	},

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -134,8 +134,9 @@ app = {
 	isEllipsisActive(element) {
 		let clone = element
 			.clone()
-			.attr('style', 'width:auto;text-overflow:unset;visibility:hidden;overflow:visible;display:inline-block !important') // we cannot use css because of !important
+			.addClass('u-text-ellipsis--not-active')
 			.appendTo('body');
+		console.log(element,clone.width(),element.width())
 		if (clone.width() > element.width()) {
 			clone.remove();
 			return true;

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -136,7 +136,6 @@ app = {
 			.clone()
 			.attr('style', 'width:auto;text-overflow:unset;visibility:hidden;overflow:visible;display:inline-block !important') // we cannot use css because of !important
 			.appendTo('body');
-		console.log(clone.innerWidth(), element.innerWidth());
 		if (clone.width() > element.width()) {
 			clone.remove();
 			return true;

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -167,6 +167,13 @@ app = {
 		return selectElement;
 	},
 	/**
+	 * Show bootstrap 4 tooltips
+	 * @param {jQuery} element
+	 */
+	showTooltipElementView(element){
+		element.tooltip();
+	},
+	/**
 	 * Function to check the maximum selection size of multiselect and update the results
 	 * @params <object> multiSelectElement
 	 * @params <object> select2 params
@@ -1460,6 +1467,7 @@ app = {
 $(document).ready(function () {
 	App.Fields.Picklist.changeSelectElementView();
 	app.showPopoverElementView($('body').find('.js-popover-tooltip'));
+	app.showTooltipElementView($('body').find('.js-tooltip'));
 	app.registerSticky();
 	app.registerMoreContent($('body').find('button.moreBtn'));
 	app.registerModal();

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -166,7 +166,6 @@ app = {
 				timeout: 150,
 				over() {
 					if (app.isEllipsisActive($(this))) {
-						console.log('truncated', this);
 						$(this).popover('show');
 					}
 				},

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -154,6 +154,9 @@ app = {
 		}, params);
 		elements.each(function (index, domElement) {
 			let element = $(domElement);
+			if(!app.isEllipsisActive(element)){
+				return;
+			}
 			let elementParams = $.extend(true, currentParams, element.data());
 			if (element.data('class')) {
 				elementParams.template = '<div class="popover ' + element.data('class') + '" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
@@ -162,16 +165,11 @@ app = {
 				elementParams.delay = {show: 0, hide: 0}
 			}
 			element.popover(elementParams);
-			element.hoverIntent({
-				timeout: 150,
-				over() {
-					if (app.isEllipsisActive($(this))) {
-						$(this).popover('show');
-					}
-				},
-				out() {
-					$(this).popover('hide');
-				}
+			element.on("mouseenter", function(){
+				$(this).popover('show');
+			});
+			element.on("mouseleave", function () {
+				$(this).popover('hide');
 			});
 		});
 		return elements;

--- a/public_html/layouts/resources/app.js
+++ b/public_html/layouts/resources/app.js
@@ -167,13 +167,6 @@ app = {
 		return selectElement;
 	},
 	/**
-	 * Show bootstrap 4 tooltips
-	 * @param {jQuery} element
-	 */
-	showTooltipElementView(element){
-		element.tooltip();
-	},
-	/**
 	 * Function to check the maximum selection size of multiselect and update the results
 	 * @params <object> multiSelectElement
 	 * @params <object> select2 params
@@ -1467,7 +1460,6 @@ app = {
 $(document).ready(function () {
 	App.Fields.Picklist.changeSelectElementView();
 	app.showPopoverElementView($('body').find('.js-popover-tooltip'));
-	app.showTooltipElementView($('body').find('.js-tooltip'));
 	app.registerSticky();
 	app.registerMoreContent($('body').find('button.moreBtn'));
 	app.registerModal();


### PR DESCRIPTION
## changed to long titles to ellipsis with tooltip on hover only when needed
## improved look & feel of the widget header
![2018-07-02-12-28-46](https://user-images.githubusercontent.com/36499752/42159349-bdbbacb0-7df3-11e8-8332-c9d23606e56a.gif)

![chrome_2018-06-29_15-51-07](https://user-images.githubusercontent.com/36499752/42096258-15701392-7bb5-11e8-8e7b-bc266b78c21a.jpg)

## responsive layout changed from

![2018-06-29_15-50-07](https://user-images.githubusercontent.com/36499752/42096271-1a93de1c-7bb5-11e8-9b75-5b68ba2dbef1.jpg)

## to

![2018-07-02_11-31-49](https://user-images.githubusercontent.com/36499752/42156521-92099a94-7deb-11e8-9eab-fe8d086e6045.jpg)


