### PR TITLE
record number uitype illegal field value bugfix, security field validation bugfix

### DIFF
--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -422,10 +422,7 @@ class Vtiger_Field_Model extends vtlib\Field
 	 */
 	public function getUITypeModel()
 	{
-		if (!$this->get('uitypeModel')) {
-			$this->set('uitypeModel', Vtiger_Base_UIType::getInstanceFromField($this));
-		}
-		return $this->get('uitypeModel');
+		return Vtiger_Base_UIType::getInstanceFromField($this);
 	}
 
 	public function isRoleBased()

--- a/modules/Vtiger/uitypes/RecordNumber.php
+++ b/modules/Vtiger/uitypes/RecordNumber.php
@@ -21,7 +21,7 @@ class Vtiger_RecordNumber_UIType extends Vtiger_Base_UIType
 		if ($maximumLength && App\TextParser::getTextLength($value) > $maximumLength) {
 			throw new \App\Exceptions\Security('ERR_VALUE_IS_TOO_LONG||' . $this->getFieldModel()->getFieldName() . '||' . $value, 406);
 		}
-		throw new \App\Exceptions\Security('ERR_ILLEGAL_FIELD_VALUE||' . $this->getFieldModel()->getFieldName() . '||' . $value, 406);
+		$this->validate = true;
 	}
 
 	/**


### PR DESCRIPTION
Before code below fails to save record if any module with record number field because by default `$this-validate` is equal to false
```php
<?php
//chdir('../../');
require_once 'include/main/WebUI.php';
$recordModel = Vtiger_Record_Model::getCleanInstance('Ideas');
$recordModel->set('assigned_user_id', 1); // some user id from db
$recordModel->set('subject', 'test');
$values = $recordModel->getValuesForSave();
$recordModel->save();
```

another commit is about field validation
if we don't return new uitypeModel we can easly ommit validation process
just for the first time we pass valid variable but for second save we can give invalid data and because of same instance of uitypemodel - model think that data is valid

before this code was valid
```php
<?php
//chdir('../../');
require_once 'include/main/WebUI.php';
$recordModel = Vtiger_Record_Model::getCleanInstance('Ideas');
$recordModel->set('assigned_user_id', 1); // some user id
$recordModel->set('subject', 'test');
$values = $recordModel->getValuesForSave();
$recordModel->save();
$recordModel->set('assigned_user_id', 'no time fot this!');
$recordModel->save();
```