### PR TITLE
Fix translate folder to library

### DIFF
--- a/app/SystemWarnings/SystemRequirements/LibraryPDF.php
+++ b/app/SystemWarnings/SystemRequirements/LibraryPDF.php
@@ -23,7 +23,7 @@ class LibraryPDF extends \App\SystemWarnings\Template
 		if ($this->status === 0) {
 			$this->link = 'index.php?module=ModuleManager&parent=Settings&view=List';
 			$this->linkTitle = \App\Language::translate('BTN_DOWNLOAD_LIBRARY', 'Settings:SystemWarnings');
-			$this->description = \App\Language::translate('LBL_MISSING_LIBRARY', 'Settings:SystemWarnings');
+			$this->description = \App\Language::translateArgs('LBL_MISSING_LIBRARY', 'Settings:SystemWarnings', \Settings_ModuleManager_Library_Model::$libraries['mPDF']['dir']);
 		}
 	}
 }

--- a/app/SystemWarnings/SystemRequirements/LibraryRoundcube.php
+++ b/app/SystemWarnings/SystemRequirements/LibraryRoundcube.php
@@ -23,7 +23,7 @@ class LibraryRoundcube extends \App\SystemWarnings\Template
 		if ($this->status === 0) {
 			$this->link = 'index.php?module=ModuleManager&parent=Settings&view=List';
 			$this->linkTitle = \App\Language::translate('BTN_DOWNLOAD_LIBRARY', 'Settings:SystemWarnings');
-			$this->description = \App\Language::translate('LBL_MISSING_LIBRARY', 'Settings:SystemWarnings');
+			$this->description = \App\Language::translateArgs('LBL_MISSING_LIBRARY', 'Settings:SystemWarnings', \Settings_ModuleManager_Library_Model::$libraries['roundcube']['dir']);
 		}
 	}
 }


### PR DESCRIPTION
from:
Wykryto, że nie została zainstalowana biblioteka. Część funkcjonalności została zablokowana, w celu odblokowania należy pobrać bibliotekę. Jeśli CRM nie ma połączenia z internetem możesz pobrać pliki i skopiować do folderu: **%s**

to:
Wykryto, że nie została zainstalowana biblioteka. Część funkcjonalności została zablokowana, w celu odblokowania należy pobrać bibliotekę. Jeśli CRM nie ma połączenia z internetem możesz pobrać pliki i skopiować do folderu: **vendor/mPDF/**