### PR TITLE
Corrected chat width on firefox

### DIFF
--- a/public_html/layouts/basic/styles/layout/_Header.scss
+++ b/public_html/layouts/basic/styles/layout/_Header.scss
@@ -110,7 +110,7 @@
 	position: fixed !important;
 	z-index: 1070;
 	overflow: hidden;
-	width: -webkit-fill-available;
+	width: 100%;
 
 	.modal-content {
 		height: 100%;


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/31520119/43706814-b0a9cf32-9966-11e8-9e57-ebd58c546b03.png)
Now:
![image](https://user-images.githubusercontent.com/31520119/43706830-bab9656e-9966-11e8-8b8e-9043f50035ba.png)
