### PR TITLE
return from function if request was not successful-infinite loop bugfix

### DIFF
--- a/public_html/layouts/basic/modules/Vtiger/resources/Detail.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/Detail.js
@@ -1064,17 +1064,20 @@ jQuery.Class("Vtiger_Detail_Js", {
 					fieldNameValueMap = thisInstance.getCustomFieldNameValueMap(fieldNameValueMap);
 					thisInstance.saveFieldValues(fieldNameValueMap).done(function (response) {
 						readRecord.prop('disabled', false);
-						var postSaveRecordDetails = response.result;
 						currentTdElement.progressIndicator({'mode': 'hide'});
 						detailViewValue.removeClass('d-none');
 						actionElement.removeClass('d-none');
-						var displayValue = postSaveRecordDetails[fieldName].display_value;
+						if(!response.success){
+							return;
+						}
+						const postSaveRecordDetails = response.result;
+						let displayValue = postSaveRecordDetails[fieldName].display_value;
 						if (dateTimeField.length && dateTime) {
 							displayValue = postSaveRecordDetails[dateTimeField[0].name].display_value + ' ' + postSaveRecordDetails[dateTimeField[1].name].display_value;
 						}
 						detailViewValue.html(displayValue);
-						if (postSaveRecordDetails['isEditable'] == false) {
-							var progressIndicatorElement = jQuery.progressIndicator({
+						if (postSaveRecordDetails['isEditable'] === false) {
+							const progressIndicatorElement = jQuery.progressIndicator({
 								'position': 'html',
 								'blockInfo': {
 									'enabled': true


### PR DESCRIPTION
## when editing fields in detail view, after some server error, infinite loop of requests was fired on click somewhere on the page

[preview](https://drive.google.com/uc?id=1qw8iOCEND2ngJGu7Drh4k4rt84OSXJRP)