### PR TITLE
module number prefix that can be refreshed each day, month or year

### DIFF
--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -41,7 +41,7 @@ class RecordNumber
 	 *
 	 * @return bool
 	 */
-	public static function setNumber($tabId, $prefix = '', $no = '', $postfix = '', $resetSequence = null)
+	public static function setNumber($tabId, $prefix = '', $no = '', $postfix = '', $resetSequence = null, $curSequence = 0)
 	{
 		if ($no != '') {
 			$db = \App\Db::getInstance();
@@ -58,7 +58,8 @@ class RecordNumber
 					'postfix' => $postfix,
 					'start_id' => $no,
 					'cur_id' => $no,
-					'reset_sequence' => $resetSequence
+					'reset_sequence' => $resetSequence,
+					'cur_sequence' => $curSequence
 				])->execute();
 
 				return true;
@@ -67,7 +68,7 @@ class RecordNumber
 					return false;
 				} else {
 					$db->createCommand()
-						->update('vtiger_modentity_num', ['cur_id' => $no, 'prefix' => $prefix, 'postfix' => $postfix, 'reset_sequence' => $resetSequence], ['tabid' => $tabId])
+						->update('vtiger_modentity_num', ['cur_id' => $no, 'prefix' => $prefix, 'postfix' => $postfix, 'reset_sequence' => $resetSequence, 'cur_sequence' => $curSequence], ['tabid' => $tabId])
 						->execute();
 
 					return true;

--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -91,7 +91,7 @@ class RecordNumber
 		if ($row['cur_sequence'] !== $actualSequence) {
 			$row['cur_id'] = 1;
 		}
-		$fullPrefix = self::parse($row['prefix'], $row['cur_id'], $row['postfix'], $row['reset_sequence']);
+		$fullPrefix = self::parse($row['prefix'], $row['cur_id'], $row['postfix']);
 		$strip = strlen($row['cur_id']) - strlen($row['cur_id'] + 1);
 		if ($strip < 0) {
 			$strip = 0;
@@ -178,7 +178,7 @@ class RecordNumber
 			'postfix' => $row['postfix'],
 			'reset_sequence' => $row['reset_sequence'],
 			'cur_sequence' => $row['cur_sequence'],
-			'number' => self::parse($row['prefix'], $row['cur_id'], $row['postfix'], $row['reset_sequence']),
+			'number' => self::parse($row['prefix'], $row['cur_id'], $row['postfix']),
 		];
 		if ($cache) {
 			self::$numberCache[$tabId] = $number;

--- a/include/CRMEntity.php
+++ b/include/CRMEntity.php
@@ -363,7 +363,7 @@ class CRMEntity
 					}
 					$dataReader->close();
 					if ($oldNumber != $sequenceNumber) {
-						\App\Fields\RecordNumber::updateNumber($sequenceNumber, $tabid);
+						\App\Fields\RecordNumber::updateNumber($sequenceNumber, $moduleData['cur_sequence'], $tabid);
 					}
 				}
 			} else {

--- a/include/CRMEntity.php
+++ b/include/CRMEntity.php
@@ -36,7 +36,7 @@ class CRMEntity
 	public $db;
 	public $ownedby;
 
-	/** 	Constructor which will set the column_fields in this object
+	/**    Constructor which will set the column_fields in this object
 	 */
 	public function __construct()
 	{
@@ -351,9 +351,10 @@ class CRMEntity
 					$sequenceNumber = $moduleData['sequenceNumber'];
 					$prefix = $moduleData['prefix'];
 					$postfix = $moduleData['postfix'];
+					$resetSequence = $moduleData['reset_sequence'];
 					$oldNumber = $sequenceNumber;
 					while ($recordinfo = $dataReader->read()) {
-						$recordNumber = \App\Fields\RecordNumber::parse($prefix . $sequenceNumber . $postfix);
+						$recordNumber = \App\Fields\RecordNumber::parse($prefix, $sequenceNumber, $postfix, $resetSequence);
 						App\Db::getInstance()->createCommand()
 							->update($fieldTable, [$fieldColumn => $recordNumber], [$this->table_index => $recordinfo['recordid']])
 							->execute();
@@ -510,7 +511,7 @@ class CRMEntity
 					while (($idFieldValue = $db->getSingleValue($selResult)) !== false) {
 						$db->update($relTableName, [
 							$entityIdField => $entityId,
-							], "$entityIdField = ? and $idField = ?", [$transferId, $idFieldValue]
+						], "$entityIdField = ? and $idField = ?", [$transferId, $idFieldValue]
 						);
 					}
 				}
@@ -520,7 +521,7 @@ class CRMEntity
 				$columnName = $field['columnname'];
 				$db->update($field['tablename'], [
 					$columnName => $entityId,
-					], "$columnName = ?", [$transferId]
+				], "$columnName = ?", [$transferId]
 				);
 			}
 		}
@@ -649,7 +650,7 @@ class CRMEntity
 		$sharingRuleInfo = $$sharingRuleInfoVariable;
 		$query = '';
 		if (!empty($sharingRuleInfo) && (count($sharingRuleInfo['ROLE']) > 0 ||
-			count($sharingRuleInfo['GROUP']) > 0)) {
+				count($sharingRuleInfo['GROUP']) > 0)) {
 			$query = ' (SELECT shareduserid FROM vtiger_tmp_read_user_sharing_per ' .
 				"WHERE userid=$userId && tabid=$tabId) UNION (SELECT " .
 				'vtiger_tmp_read_group_sharing_per.sharedgroupid FROM ' .

--- a/include/CRMEntity.php
+++ b/include/CRMEntity.php
@@ -351,10 +351,9 @@ class CRMEntity
 					$sequenceNumber = $moduleData['sequenceNumber'];
 					$prefix = $moduleData['prefix'];
 					$postfix = $moduleData['postfix'];
-					$resetSequence = $moduleData['reset_sequence'];
 					$oldNumber = $sequenceNumber;
 					while ($recordinfo = $dataReader->read()) {
-						$recordNumber = \App\Fields\RecordNumber::parse($prefix, $sequenceNumber, $postfix, $resetSequence);
+						$recordNumber = \App\Fields\RecordNumber::parse($prefix, $sequenceNumber, $postfix);
 						App\Db::getInstance()->createCommand()
 							->update($fieldTable, [$fieldColumn => $recordNumber], [$this->table_index => $recordinfo['recordid']])
 							->execute();

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -6580,6 +6580,7 @@ CREATE TABLE `vtiger_modentity_num` (
   `start_id` int(10) unsigned NOT NULL,
   `cur_id` int(10) unsigned NOT NULL,
   `reset_sequence` char,
+  `cur_sequence` int DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `semodule` (`cur_id`),
   KEY `prefix` (`prefix`,`postfix`,`cur_id`),

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -6579,6 +6579,7 @@ CREATE TABLE `vtiger_modentity_num` (
   `postfix` varchar(50) NOT NULL DEFAULT '',
   `start_id` int(10) unsigned NOT NULL,
   `cur_id` int(10) unsigned NOT NULL,
+  `reset_sequence` char,
   PRIMARY KEY (`id`),
   KEY `semodule` (`cur_id`),
   KEY `prefix` (`prefix`,`postfix`,`cur_id`),

--- a/languages/pl_pl/Settings/_Base.json
+++ b/languages/pl_pl/Settings/_Base.json
@@ -279,6 +279,12 @@
     "LBL_CV_YEAR": "Rok (np. 15)",
     "LBL_CV_MONTH": "Miesi\u0105c (np. 1, 5, 12)",
     "LBL_CV_DAY": "Dzie\u0144 (np. 1, 5, 25)",
+    "LBL_CV_LEADING_ZERO": "Wiod\u0105ce zero (np. trzy w. zera dzadzą wynik 002, 011, 563, 2342)",
+    "LBL_RS_RESET_SEQUENCE": "Resetuj numer",
+    "LBL_RS_DO_NOT": "Nie resetuj nigdy (numery rekord\u00F3w rosn\u0105 w niesko\u0144czono\u015B\u0107)",
+    "LBL_RS_YEAR": "Resetuj z nowym rokiem",
+    "LBL_RS_MONTH": "Resetuj z nowym miesi\u0105cem",
+    "LBL_RS_DAY": "Resetuj z nowym dniem",
     "LBL_DONATE_US": "Wspieraj nas",
     "LBL_START": "Start",
     "LBL_GITHUB": "Github",
@@ -381,6 +387,9 @@
     "LBL_WRONG_IMAGE_TYPE": "niewspierany format pliku",
     "JS_COLUMN_ADDED": "Pole dodane",
     "JS_COLUMN_EXIST": "B\u0142\u0105d przy dodaniu pola",
-    "JS_NOTIFY_COPY_TEXT": "Skopiowano zmienn\u0105 do schowka"
+    "JS_NOTIFY_COPY_TEXT": "Skopiowano zmienn\u0105 do schowka",
+    "JS_RS_ADD_YEAR_VARIABLE": "Skopiuj zmienn\u0105 typu rok do prefiksu lub postfixu",
+    "JS_RS_ADD_MONTH_VARIABLE": "Skopiuj zmienn\u0105 typu miesi\u0105c do prefiksu lub postfiksu",
+    "JS_RS_ADD_DAY_VARIABLE": "Skopiuj zmienn\u0105 typu dzie\u0144 do prefiksu lub postfixu"
   }
 }

--- a/layouts/basic/modules/Settings/Vtiger/CustomRecordNumbering.tpl
+++ b/layouts/basic/modules/Settings/Vtiger/CustomRecordNumbering.tpl
@@ -77,6 +77,21 @@
 							</tr>
 							<tr>
 								<td class="{$WIDTHTYPE}">
+									<label class="float-right marginRight10px">
+										<b>{\App\Language::translate('LBL_RS_RESET_SEQUENCE', $QUALIFIED_MODULE)}</b>
+									</label>
+								</td>
+								<td class="fieldValue {$WIDTHTYPE}" style="border-left: none">
+									<select class="select2" name="reset_sequence" data-allow-clear="true" data-placeholder="{\App\Language::translate('LBL_RS_RESET_SEQUENCE', $QUALIFIED_MODULE)}">
+										<option></option>
+										<option value="Y">{\App\Language::translate('LBL_RS_YEAR',$QUALIFIED_MODULE)}</option>
+										<option value="M">{\App\Language::translate('LBL_RS_MONTH',$QUALIFIED_MODULE)}</option>
+										<option value="D">{\App\Language::translate('LBL_RS_DAY',$QUALIFIED_MODULE)}</option>
+									</select>
+								</td>
+							</tr>
+							<tr>
+								<td class="{$WIDTHTYPE}">
 									<label class="float-right marginRight10px"><b>{\App\Language::translate('LBL_USE_POSTFIX', $QUALIFIED_MODULE)}</b></label>
 								</td>
 								<td class="fieldValue {$WIDTHTYPE}" style="border-left: none">
@@ -113,6 +128,7 @@
 												<option value="M">{\App\Language::translate('LBL_CV_MONTH', $QUALIFIED_MODULE)}</option>
 												<option value="DD">{\App\Language::translate('LBL_CV_FULL_DAY', $QUALIFIED_MODULE)}</option>
 												<option value="D">{\App\Language::translate('LBL_CV_DAY', $QUALIFIED_MODULE)}</option>
+												<option value="0">{\App\Language::translate('LBL_CV_LEADING_ZERO', $QUALIFIED_MODULE)}</option>
 											</select>
 										</div>
 										<div class="col-md-1">

--- a/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
+++ b/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
@@ -66,6 +66,7 @@ class Settings_Vtiger_CustomRecordNumberingAjax_Action extends Settings_Vtiger_I
 		$moduleModel->set('prefix', $request->get('prefix'));
 		$moduleModel->set('sequenceNumber', $request->get('sequenceNumber'));
 		$moduleModel->set('postfix', $request->get('postfix'));
+		$moduleModel->set('reset_sequence', $request->get('reset_sequence'));
 		$result = $moduleModel->setModuleSequence();
 		$response = new Vtiger_Response();
 		if ($result['success']) {

--- a/modules/Settings/Vtiger/models/CustomRecordNumberingModule.php
+++ b/modules/Settings/Vtiger/models/CustomRecordNumberingModule.php
@@ -66,8 +66,9 @@ class Settings_Vtiger_CustomRecordNumberingModule_Model extends Vtiger_Module_Mo
 	{
 		$prefix = $this->get('prefix');
 		$postfix = $this->get('postfix');
+		$resetSequence = $this->get('reset_sequence');
 		$tabId = \App\Module::getModuleId($this->getName());
-		$status = \App\Fields\RecordNumber::setNumber($tabId, $prefix, $this->get('sequenceNumber'), $postfix);
+		$status = \App\Fields\RecordNumber::setNumber($tabId, $prefix, $this->get('sequenceNumber'), $postfix, $resetSequence);
 		$success = ['success' => $status];
 		if (!$status) {
 			$success['sequenceNumber'] = (new App\Db\Query())->select(['cur_id'])

--- a/modules/Vtiger/uitypes/RecordNumber.php
+++ b/modules/Vtiger/uitypes/RecordNumber.php
@@ -4,8 +4,8 @@
  * UIType Record Number Field Class.
  *
  * @copyright YetiForce Sp. z o.o
- * @license YetiForce Public License 3.0 (licenses/LicenseEN.txt or yetiforce.com)
- * @author Mariusz Krzaczkowski <m.krzaczkowski@yetiforce.com>
+ * @license   YetiForce Public License 3.0 (licenses/LicenseEN.txt or yetiforce.com)
+ * @author    Mariusz Krzaczkowski <m.krzaczkowski@yetiforce.com>
  */
 class Vtiger_RecordNumber_UIType extends Vtiger_Base_UIType
 {


### PR DESCRIPTION
## added ablity to refresh/reset sequence number each day, month or year so invoice numbers for example could look like this: FI08/0123 FI09/0001 - numbers are refreshed automatically 

![chrome_2018-08-06_17-50-36](https://user-images.githubusercontent.com/36499752/43727221-a7a5969c-99a1-11e8-99ee-b8d327ba3977.jpg)
