### PR TITLE
added ability to automatically reset record number with date change (for invoice for example), added leading zeros param in prefix

### DIFF
--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -66,9 +66,9 @@ class RecordNumber
 			if (!is_numeric($tabId)) {
 				$tabId = \App\Module::getModuleId($tabId);
 			}
-			$current = (new \App\Db\Query())->from('vtiger_modentity_num')->noCache()->where(['tabid' => $tabId])->one();
+			$current = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => $tabId])->one();
 			if (!$current['cur_id']) {
-				return $db->createCommand()->noCache()->insert('vtiger_modentity_num', [
+				return $db->createCommand()->insert('vtiger_modentity_num', [
 					'tabid' => $tabId,
 					'prefix' => $prefix,
 					'postfix' => $postfix,
@@ -78,7 +78,7 @@ class RecordNumber
 					'cur_sequence' => $curSequence
 				])->execute();
 			} else {
-				return $db->createCommand()->noCache()
+				return $db->createCommand()
 					->update('vtiger_modentity_num', ['cur_id' => $no, 'prefix' => $prefix, 'postfix' => $postfix, 'reset_sequence' => $resetSequence, 'cur_sequence' => $curSequence], ['tabid' => $tabId])
 					->execute();
 			}
@@ -94,7 +94,7 @@ class RecordNumber
 	 */
 	public static function incrementNumber($moduleId)
 	{
-		$row = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => $moduleId])->noCache()->one();
+		$row = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => $moduleId])->one();
 		$actualSequence = static::getSequenceNumber($row['reset_sequence']);
 		if ($row['reset_sequence'] && $row['cur_sequence'] !== $actualSequence) {
 			$row['cur_id'] = 1;

--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -153,8 +153,9 @@ class RecordNumber
 	/**
 	 * Function updates module number.
 	 *
-	 * @param int $curId
-	 * @param int $tabId
+	 * @param int    $curId
+	 * @param string $curSequence
+	 * @param int    $tabId
 	 */
 	public static function updateNumber($curId, $curSequence, $tabId)
 	{
@@ -166,8 +167,7 @@ class RecordNumber
 	/**
 	 * Function returns information about module numbering.
 	 *
-	 * @param int    $tabId
-	 * @param boolen $cache
+	 * @param int $tabId
 	 *
 	 * @return array
 	 */

--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -41,7 +41,7 @@ class RecordNumber
 	 *
 	 * @return bool
 	 */
-	public static function setNumber($tabId, $prefix = '', $no = '', $postfix = '', $resetSequence = null)
+	public static function setNumber($tabId, $prefix = '', $no = '', $postfix = '', $resetSequence = null, $curSequence = 0)
 	{
 		if ($no != '') {
 			$db = \App\Db::getInstance();
@@ -58,7 +58,8 @@ class RecordNumber
 					'postfix' => $postfix,
 					'start_id' => $no,
 					'cur_id' => $no,
-					'reset_sequence' => $resetSequence
+					'reset_sequence' => $resetSequence,
+					'cur_sequence' => $curSequence
 				])->execute();
 
 				return true;
@@ -67,7 +68,7 @@ class RecordNumber
 					return false;
 				} else {
 					$db->createCommand()
-						->update('vtiger_modentity_num', ['cur_id' => $no, 'prefix' => $prefix, 'postfix' => $postfix, 'reset_sequence' => $resetSequence], ['tabid' => $tabId])
+						->update('vtiger_modentity_num', ['cur_id' => $no, 'prefix' => $prefix, 'postfix' => $postfix, 'reset_sequence' => $resetSequence, 'cur_sequence' => $curSequence], ['tabid' => $tabId])
 						->execute();
 
 					return true;

--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -15,8 +15,8 @@ class RecordNumber
 	/**
 	 * Date function that can be overrided in tests.
 	 *
-	 * @param      $format
-	 * @param null $time
+	 * @param string   $format
+	 * @param null|int $time
 	 *
 	 * @return false|string
 	 */
@@ -50,10 +50,12 @@ class RecordNumber
 	/**
 	 * Function to set number sequence of recoords for module.
 	 *
-	 * @param mixed  $tabId
-	 * @param string $prefix
-	 * @param int    $no
-	 * @param string $postfix
+	 * @param mixed       $tabId
+	 * @param string      $prefix
+	 * @param int         $no
+	 * @param string      $postfix
+	 * @param null|string $resetSequence 'Y'-Year, 'M'-Month, 'D'-Day
+	 * @param string      $curSequence   '201804' for example for M reset sequence
 	 *
 	 * @return bool
 	 */

--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -91,7 +91,7 @@ class RecordNumber
 		if ($row['cur_sequence'] !== $actualSequence) {
 			$row['cur_id'] = 1;
 		}
-		$fullPrefix = self::parse($row['prefix'], $row['cur_id'], $row['postfix'], $row['reset_sequence']);
+		$fullPrefix = self::parse($row['prefix'], $row['cur_id'], $row['postfix']);
 		$strip = strlen($row['cur_id']) - strlen($row['cur_id'] + 1);
 		if ($strip < 0) {
 			$strip = 0;
@@ -178,7 +178,7 @@ class RecordNumber
 			'postfix' => $row['postfix'],
 			'reset_sequence' => $row['reset_sequence'],
 			'cur_sequence' => $row['cur_sequence'],
-			'number' => self::parse($row['prefix'], $row['cur_id'], $row['postfix'], $row['reset_sequence']),
+			'number' => self::parse($row['prefix'], $row['cur_id'], $row['postfix']),
 		];
 		if ($cache) {
 			self::$numberCache[$tabId] = $number;

--- a/app/Fields/RecordNumber.php
+++ b/app/Fields/RecordNumber.php
@@ -136,7 +136,9 @@ class RecordNumber
 	 *
 	 * @see Important: When you add new parameter in this function you also must add it in Email::findRecordNumber()
 	 *
-	 * @param string $content
+	 * @param string $prefix
+	 * @param string $number
+	 * @param string $postfix
 	 *
 	 * @return string
 	 */

--- a/include/CRMEntity.php
+++ b/include/CRMEntity.php
@@ -363,7 +363,7 @@ class CRMEntity
 					}
 					$dataReader->close();
 					if ($oldNumber != $sequenceNumber) {
-						\App\Fields\RecordNumber::updateNumber($sequenceNumber, $tabid);
+						\App\Fields\RecordNumber::updateNumber($sequenceNumber, $moduleData['cur_sequence'], $tabid);
 					}
 				}
 			} else {

--- a/include/CRMEntity.php
+++ b/include/CRMEntity.php
@@ -36,7 +36,7 @@ class CRMEntity
 	public $db;
 	public $ownedby;
 
-	/** 	Constructor which will set the column_fields in this object
+	/**    Constructor which will set the column_fields in this object
 	 */
 	public function __construct()
 	{
@@ -351,9 +351,10 @@ class CRMEntity
 					$sequenceNumber = $moduleData['sequenceNumber'];
 					$prefix = $moduleData['prefix'];
 					$postfix = $moduleData['postfix'];
+					$resetSequence = $moduleData['reset_sequence'];
 					$oldNumber = $sequenceNumber;
 					while ($recordinfo = $dataReader->read()) {
-						$recordNumber = \App\Fields\RecordNumber::parse($prefix . $sequenceNumber . $postfix);
+						$recordNumber = \App\Fields\RecordNumber::parse($prefix, $sequenceNumber, $postfix, $resetSequence);
 						App\Db::getInstance()->createCommand()
 							->update($fieldTable, [$fieldColumn => $recordNumber], [$this->table_index => $recordinfo['recordid']])
 							->execute();
@@ -510,7 +511,7 @@ class CRMEntity
 					while (($idFieldValue = $db->getSingleValue($selResult)) !== false) {
 						$db->update($relTableName, [
 							$entityIdField => $entityId,
-							], "$entityIdField = ? and $idField = ?", [$transferId, $idFieldValue]
+						], "$entityIdField = ? and $idField = ?", [$transferId, $idFieldValue]
 						);
 					}
 				}
@@ -520,7 +521,7 @@ class CRMEntity
 				$columnName = $field['columnname'];
 				$db->update($field['tablename'], [
 					$columnName => $entityId,
-					], "$columnName = ?", [$transferId]
+				], "$columnName = ?", [$transferId]
 				);
 			}
 		}
@@ -649,7 +650,7 @@ class CRMEntity
 		$sharingRuleInfo = $$sharingRuleInfoVariable;
 		$query = '';
 		if (!empty($sharingRuleInfo) && (count($sharingRuleInfo['ROLE']) > 0 ||
-			count($sharingRuleInfo['GROUP']) > 0)) {
+				count($sharingRuleInfo['GROUP']) > 0)) {
 			$query = ' (SELECT shareduserid FROM vtiger_tmp_read_user_sharing_per ' .
 				"WHERE userid=$userId && tabid=$tabId) UNION (SELECT " .
 				'vtiger_tmp_read_group_sharing_per.sharedgroupid FROM ' .

--- a/include/CRMEntity.php
+++ b/include/CRMEntity.php
@@ -351,10 +351,9 @@ class CRMEntity
 					$sequenceNumber = $moduleData['sequenceNumber'];
 					$prefix = $moduleData['prefix'];
 					$postfix = $moduleData['postfix'];
-					$resetSequence = $moduleData['reset_sequence'];
 					$oldNumber = $sequenceNumber;
 					while ($recordinfo = $dataReader->read()) {
-						$recordNumber = \App\Fields\RecordNumber::parse($prefix, $sequenceNumber, $postfix, $resetSequence);
+						$recordNumber = \App\Fields\RecordNumber::parse($prefix, $sequenceNumber, $postfix);
 						App\Db::getInstance()->createCommand()
 							->update($fieldTable, [$fieldColumn => $recordNumber], [$this->table_index => $recordinfo['recordid']])
 							->execute();

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -6580,6 +6580,7 @@ CREATE TABLE `vtiger_modentity_num` (
   `start_id` int(10) unsigned NOT NULL,
   `cur_id` int(10) unsigned NOT NULL,
   `reset_sequence` char,
+  `cur_sequence` int DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `semodule` (`cur_id`),
   KEY `prefix` (`prefix`,`postfix`,`cur_id`),

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -6579,6 +6579,7 @@ CREATE TABLE `vtiger_modentity_num` (
   `postfix` varchar(50) NOT NULL DEFAULT '',
   `start_id` int(10) unsigned NOT NULL,
   `cur_id` int(10) unsigned NOT NULL,
+  `reset_sequence` char,
   PRIMARY KEY (`id`),
   KEY `semodule` (`cur_id`),
   KEY `prefix` (`prefix`,`postfix`,`cur_id`),

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -6579,7 +6579,7 @@ CREATE TABLE `vtiger_modentity_num` (
   `postfix` varchar(50) NOT NULL DEFAULT '',
   `start_id` int(10) unsigned NOT NULL,
   `cur_id` int(10) unsigned NOT NULL,
-  `reset_sequence` char,
+  `reset_sequence` char(1),
   `cur_sequence` varchar(10) DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `semodule` (`cur_id`),

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -6580,7 +6580,7 @@ CREATE TABLE `vtiger_modentity_num` (
   `start_id` int(10) unsigned NOT NULL,
   `cur_id` int(10) unsigned NOT NULL,
   `reset_sequence` char,
-  `cur_sequence` int DEFAULT 0,
+  `cur_sequence` varchar(10) DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `semodule` (`cur_id`),
   KEY `prefix` (`prefix`,`postfix`,`cur_id`),

--- a/languages/pl_pl/Settings/_Base.json
+++ b/languages/pl_pl/Settings/_Base.json
@@ -279,6 +279,12 @@
     "LBL_CV_YEAR": "Rok (np. 15)",
     "LBL_CV_MONTH": "Miesi\u0105c (np. 1, 5, 12)",
     "LBL_CV_DAY": "Dzie\u0144 (np. 1, 5, 25)",
+    "LBL_CV_LEADING_ZERO": "Wiod\u0105ce zero (np. trzy w. zera dzadzą wynik 002, 011, 563, 2342)",
+    "LBL_RS_RESET_SEQUENCE": "Resetuj numer",
+    "LBL_RS_DO_NOT": "Nie resetuj nigdy (numery rekord\u00F3w rosn\u0105 w niesko\u0144czono\u015B\u0107)",
+    "LBL_RS_YEAR": "Resetuj z nowym rokiem",
+    "LBL_RS_MONTH": "Resetuj z nowym miesi\u0105cem",
+    "LBL_RS_DAY": "Resetuj z nowym dniem",
     "LBL_DONATE_US": "Wspieraj nas",
     "LBL_START": "Start",
     "LBL_GITHUB": "Github",
@@ -381,6 +387,9 @@
     "LBL_WRONG_IMAGE_TYPE": "niewspierany format pliku",
     "JS_COLUMN_ADDED": "Pole dodane",
     "JS_COLUMN_EXIST": "B\u0142\u0105d przy dodaniu pola",
-    "JS_NOTIFY_COPY_TEXT": "Skopiowano zmienn\u0105 do schowka"
+    "JS_NOTIFY_COPY_TEXT": "Skopiowano zmienn\u0105 do schowka",
+    "JS_RS_ADD_YEAR_VARIABLE": "Skopiuj zmienn\u0105 typu rok do prefiksu lub postfixu",
+    "JS_RS_ADD_MONTH_VARIABLE": "Skopiuj zmienn\u0105 typu miesi\u0105c do prefiksu lub postfiksu",
+    "JS_RS_ADD_DAY_VARIABLE": "Skopiuj zmienn\u0105 typu dzie\u0144 do prefiksu lub postfixu"
   }
 }

--- a/languages/pl_pl/Settings/_Base.json
+++ b/languages/pl_pl/Settings/_Base.json
@@ -279,7 +279,7 @@
     "LBL_CV_YEAR": "Rok (np. 15)",
     "LBL_CV_MONTH": "Miesi\u0105c (np. 1, 5, 12)",
     "LBL_CV_DAY": "Dzie\u0144 (np. 1, 5, 25)",
-    "LBL_CV_LEADING_ZERO": "Wiod\u0105ce zero (np. trzy w. zera dzadzą wynik 002, 011, 563, 2342)",
+    "LBL_CV_LEADING_ZERO": "Wiod\u0105ce zero (np. trzy w. zera dzadz\u0105 wynik 002, 011, 563, 2342)",
     "LBL_RS_RESET_SEQUENCE": "Resetuj numer",
     "LBL_RS_DO_NOT": "Nie resetuj nigdy (numery rekord\u00F3w rosn\u0105 w niesko\u0144czono\u015B\u0107)",
     "LBL_RS_YEAR": "Resetuj z nowym rokiem",

--- a/layouts/basic/modules/Settings/Vtiger/CustomRecordNumbering.tpl
+++ b/layouts/basic/modules/Settings/Vtiger/CustomRecordNumbering.tpl
@@ -77,6 +77,21 @@
 							</tr>
 							<tr>
 								<td class="{$WIDTHTYPE}">
+									<label class="float-right marginRight10px">
+										<b>{\App\Language::translate('LBL_RS_RESET_SEQUENCE', $QUALIFIED_MODULE)}</b>
+									</label>
+								</td>
+								<td class="fieldValue {$WIDTHTYPE}" style="border-left: none">
+									<select class="select2" name="reset_sequence" data-allow-clear="true" data-placeholder="{\App\Language::translate('LBL_RS_RESET_SEQUENCE', $QUALIFIED_MODULE)}">
+										<option></option>
+										<option value="Y">{\App\Language::translate('LBL_RS_YEAR',$QUALIFIED_MODULE)}</option>
+										<option value="M">{\App\Language::translate('LBL_RS_MONTH',$QUALIFIED_MODULE)}</option>
+										<option value="D">{\App\Language::translate('LBL_RS_DAY',$QUALIFIED_MODULE)}</option>
+									</select>
+								</td>
+							</tr>
+							<tr>
+								<td class="{$WIDTHTYPE}">
 									<label class="float-right marginRight10px"><b>{\App\Language::translate('LBL_USE_POSTFIX', $QUALIFIED_MODULE)}</b></label>
 								</td>
 								<td class="fieldValue {$WIDTHTYPE}" style="border-left: none">
@@ -113,6 +128,7 @@
 												<option value="M">{\App\Language::translate('LBL_CV_MONTH', $QUALIFIED_MODULE)}</option>
 												<option value="DD">{\App\Language::translate('LBL_CV_FULL_DAY', $QUALIFIED_MODULE)}</option>
 												<option value="D">{\App\Language::translate('LBL_CV_DAY', $QUALIFIED_MODULE)}</option>
+												<option value="0">{\App\Language::translate('LBL_CV_LEADING_ZERO', $QUALIFIED_MODULE)}</option>
 											</select>
 										</div>
 										<div class="col-md-1">

--- a/layouts/basic/modules/Settings/Vtiger/CustomRecordNumbering.tpl
+++ b/layouts/basic/modules/Settings/Vtiger/CustomRecordNumbering.tpl
@@ -84,9 +84,9 @@
 								<td class="fieldValue {$WIDTHTYPE}" style="border-left: none">
 									<select class="select2" name="reset_sequence" data-allow-clear="true" data-placeholder="{\App\Language::translate('LBL_RS_RESET_SEQUENCE', $QUALIFIED_MODULE)}">
 										<option></option>
-										<option value="Y">{\App\Language::translate('LBL_RS_YEAR',$QUALIFIED_MODULE)}</option>
-										<option value="M">{\App\Language::translate('LBL_RS_MONTH',$QUALIFIED_MODULE)}</option>
-										<option value="D">{\App\Language::translate('LBL_RS_DAY',$QUALIFIED_MODULE)}</option>
+										<option value="Y"{if $DEFAULT_MODULE_DATA['reset_sequence']==='Y'} selected {/if}>{\App\Language::translate('LBL_RS_YEAR',$QUALIFIED_MODULE)}</option>
+										<option value="M"{if $DEFAULT_MODULE_DATA['reset_sequence']==='M'} selected {/if}>{\App\Language::translate('LBL_RS_MONTH',$QUALIFIED_MODULE)}</option>
+										<option value="D"{if $DEFAULT_MODULE_DATA['reset_sequence']==='D'} selected {/if}>{\App\Language::translate('LBL_RS_DAY',$QUALIFIED_MODULE)}</option>
 									</select>
 								</td>
 							</tr>

--- a/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
+++ b/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
@@ -63,10 +63,10 @@ class Settings_Vtiger_CustomRecordNumberingAjax_Action extends Settings_Vtiger_I
 	{
 		$qualifiedModuleName = $request->getModule(false);
 		$moduleModel = Settings_Vtiger_CustomRecordNumberingModule_Model::getInstance($request->getByType('sourceModule', 2));
-		$moduleModel->set('prefix', $request->get('prefix'));
-		$moduleModel->set('sequenceNumber', $request->get('sequenceNumber'));
-		$moduleModel->set('postfix', $request->get('postfix'));
-		$moduleModel->set('reset_sequence', $request->get('reset_sequence'));
+		$moduleModel->set('prefix', $request->getByType('prefix', 'Text'));
+		$moduleModel->set('sequenceNumber', $request->getByType('sequenceNumber', 'Integer'));
+		$moduleModel->set('postfix', $request->getByType('postfix', 'Text'));
+		$moduleModel->set('reset_sequence', $request->getByType('reset_sequence', 'Standard'));
 		$result = $moduleModel->setModuleSequence();
 		$response = new Vtiger_Response();
 		if ($result['success']) {

--- a/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
+++ b/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
@@ -66,6 +66,7 @@ class Settings_Vtiger_CustomRecordNumberingAjax_Action extends Settings_Vtiger_I
 		$moduleModel->set('prefix', $request->get('prefix'));
 		$moduleModel->set('sequenceNumber', $request->get('sequenceNumber'));
 		$moduleModel->set('postfix', $request->get('postfix'));
+		$moduleModel->set('reset_sequence', $request->get('reset_sequence'));
 		$result = $moduleModel->setModuleSequence();
 		$response = new Vtiger_Response();
 		if ($result['success']) {

--- a/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
+++ b/modules/Settings/Vtiger/actions/CustomRecordNumberingAjax.php
@@ -66,7 +66,7 @@ class Settings_Vtiger_CustomRecordNumberingAjax_Action extends Settings_Vtiger_I
 		$moduleModel->set('prefix', $request->getByType('prefix', 'Text'));
 		$moduleModel->set('sequenceNumber', $request->getByType('sequenceNumber', 'Integer'));
 		$moduleModel->set('postfix', $request->getByType('postfix', 'Text'));
-		$moduleModel->set('reset_sequence', $request->getByType('reset_sequence', 'Standard'));
+		$moduleModel->set('reset_sequence', $request->getByType('reset_sequence'));
 		$result = $moduleModel->setModuleSequence();
 		$response = new Vtiger_Response();
 		if ($result['success']) {

--- a/modules/Settings/Vtiger/models/CustomRecordNumberingModule.php
+++ b/modules/Settings/Vtiger/models/CustomRecordNumberingModule.php
@@ -66,8 +66,9 @@ class Settings_Vtiger_CustomRecordNumberingModule_Model extends Vtiger_Module_Mo
 	{
 		$prefix = $this->get('prefix');
 		$postfix = $this->get('postfix');
+		$resetSequence = $this->get('reset_sequence');
 		$tabId = \App\Module::getModuleId($this->getName());
-		$status = \App\Fields\RecordNumber::setNumber($tabId, $prefix, $this->get('sequenceNumber'), $postfix);
+		$status = \App\Fields\RecordNumber::setNumber($tabId, $prefix, $this->get('sequenceNumber'), $postfix, $resetSequence);
 		$success = ['success' => $status];
 		if (!$status) {
 			$success['sequenceNumber'] = (new App\Db\Query())->select(['cur_id'])

--- a/modules/Settings/Vtiger/models/CustomRecordNumberingModule.php
+++ b/modules/Settings/Vtiger/models/CustomRecordNumberingModule.php
@@ -66,9 +66,8 @@ class Settings_Vtiger_CustomRecordNumberingModule_Model extends Vtiger_Module_Mo
 	{
 		$prefix = $this->get('prefix');
 		$postfix = $this->get('postfix');
-		$resetSequence = $this->get('reset_sequence');
 		$tabId = \App\Module::getModuleId($this->getName());
-		$status = \App\Fields\RecordNumber::setNumber($tabId, $prefix, $this->get('sequenceNumber'), $postfix, $resetSequence);
+		$status = \App\Fields\RecordNumber::setNumber($tabId, $prefix, $this->get('sequenceNumber'), $postfix, $this->get('reset_sequence'));
 		$success = ['success' => $status];
 		if (!$status) {
 			$success['sequenceNumber'] = (new App\Db\Query())->select(['cur_id'])

--- a/modules/Vtiger/uitypes/RecordNumber.php
+++ b/modules/Vtiger/uitypes/RecordNumber.php
@@ -4,8 +4,8 @@
  * UIType Record Number Field Class.
  *
  * @copyright YetiForce Sp. z o.o
- * @license YetiForce Public License 3.0 (licenses/LicenseEN.txt or yetiforce.com)
- * @author Mariusz Krzaczkowski <m.krzaczkowski@yetiforce.com>
+ * @license   YetiForce Public License 3.0 (licenses/LicenseEN.txt or yetiforce.com)
+ * @author    Mariusz Krzaczkowski <m.krzaczkowski@yetiforce.com>
  */
 class Vtiger_RecordNumber_UIType extends Vtiger_Base_UIType
 {

--- a/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
+++ b/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
@@ -94,12 +94,13 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 	registerEventToUpdateRecordsWithSequenceNumber() {
 		const editViewForm = this.getForm();
 		editViewForm.find('[name="updateRecordWithSequenceNumber"]').on('click', function () {
+			const sourceModule = editViewForm.find('[name="sourceModule"]').val();
 			AppConnector.request({
 				'module': app.getModuleName(),
 				'parent': app.getParentModuleName(),
 				'action': "CustomRecordNumberingAjax",
 				'mode': "updateRecordsWithSequenceNumber",
-				'sourceModule': editViewForm.find('[name="sourceModule"]').val()
+				'sourceModule': sourceModule
 			}).done(function (data) {
 				if (data.success === true) {
 					Settings_Vtiger_Index_Js.showMessage({text: app.vtranslate('JS_RECORD_NUMBERING_UPDATED_SUCCESSFULLY_FOR') + " " + editViewForm.find('option[value="' + sourceModule + '"]').text()});

--- a/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
+++ b/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
@@ -68,7 +68,8 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 			sequenceNumberElement.validationEngine('showPrompt', app.vtranslate('JS_SEQUENCE_NUMBER_MESSAGE') + " " + oldSequenceNumber, 'error', 'topLeft', true);
 			return;
 		}
-		const params = {
+		$('.saveButton').attr("disabled", "disabled");
+		AppConnector.request({
 			'module': app.getModuleName(),
 			'parent': app.getParentModuleName(),
 			'action': "CustomRecordNumberingAjax",
@@ -78,9 +79,7 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 			'postfix': currentPostfix,
 			'sequenceNumber': sequenceNumber,
 			'reset_sequence': editViewForm.find('[name="reset_sequence"]').val(),
-		};
-		$('.saveButton').attr("disabled", "disabled");
-		AppConnector.request(params).done(function (data) {
+		}).done(function (data) {
 			if (data.success === true) {
 				Settings_Vtiger_Index_Js.showMessage({
 					text: app.vtranslate('JS_RECORD_NUMBERING_SAVED_SUCCESSFULLY_FOR') + " " + editViewForm.find('option[value="' + sourceModule + '"]').text()

--- a/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
+++ b/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
@@ -32,7 +32,6 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 				'mode': "getModuleCustomNumberingData",
 				'sourceModule': $(e.currentTarget).val()
 			}).done(function (data) {
-				console.log(data);
 				if (data) {
 					editViewForm.find('[name="prefix"]').val(data.result.prefix);
 					editViewForm.find('[name="reset_sequence"]').val(data.result.reset_sequence).trigger('change');

--- a/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
+++ b/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
@@ -22,24 +22,20 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 	 * Function to register change event for source module field
 	 */
 	registerOnChangeEventOfSourceModule: function () {
-		var editViewForm = this.getForm();
+		const editViewForm = this.getForm();
 		editViewForm.find('[name="sourceModule"]').on('change', function (e) {
-			jQuery('.saveButton').removeAttr('disabled');
-			var element = jQuery(e.currentTarget);
-			var params = {};
-			var sourceModule = element.val();
-
-			params = {
+			$('.saveButton').removeAttr('disabled');
+			AppConnector.request({
 				'module': app.getModuleName(),
 				'parent': app.getParentModuleName(),
 				'action': "CustomRecordNumberingAjax",
 				'mode': "getModuleCustomNumberingData",
-				'sourceModule': sourceModule
-			}
-
-			AppConnector.request(params).done(function (data) {
+				'sourceModule': $(e.currentTarget).val()
+			}).done(function (data) {
+				console.log(data);
 				if (data) {
 					editViewForm.find('[name="prefix"]').val(data.result.prefix);
+					editViewForm.find('[name="reset_sequence"]').val(data.result.reset_sequence).trigger('change');
 					editViewForm.find('[name="postfix"]').val(data.result.postfix);
 					editViewForm.find('[name="sequenceNumber"]').val(data.result.sequenceNumber);
 					editViewForm.find('[name="sequenceNumber"]').data('oldSequenceNumber', data.result.sequenceNumber);
@@ -51,7 +47,7 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 	/**
 	 * Function to register event for saving module custom numbering
 	 */
-	saveModuleCustomNumbering: function () {
+	saveModuleCustomNumbering() {
 		if ($('.saveButton').attr("disabled")) {
 			return;
 		}
@@ -96,25 +92,18 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 	/**
 	 * Function to handle update record with the given sequence number
 	 */
-	registerEventToUpdateRecordsWithSequenceNumber: function () {
-		var editViewForm = this.getForm();
+	registerEventToUpdateRecordsWithSequenceNumber() {
+		const editViewForm = this.getForm();
 		editViewForm.find('[name="updateRecordWithSequenceNumber"]').on('click', function () {
-			var params = {};
-			var sourceModule = editViewForm.find('[name="sourceModule"]').val();
-			var sourceModuleLabel = editViewForm.find('option[value="' + sourceModule + '"]').text();
-
-			params = {
+			AppConnector.request({
 				'module': app.getModuleName(),
 				'parent': app.getParentModuleName(),
 				'action': "CustomRecordNumberingAjax",
 				'mode': "updateRecordsWithSequenceNumber",
-				'sourceModule': sourceModule
-			}
-
-			AppConnector.request(params).done(function (data) {
-				var successfullSaveMessage = app.vtranslate('JS_RECORD_NUMBERING_UPDATED_SUCCESSFULLY_FOR') + " " + sourceModuleLabel;
-				if (data.success == true) {
-					Settings_Vtiger_Index_Js.showMessage({text: successfullSaveMessage});
+				'sourceModule': editViewForm.find('[name="sourceModule"]').val()
+			}).done(function (data) {
+				if (data.success === true) {
+					Settings_Vtiger_Index_Js.showMessage({text: app.vtranslate('JS_RECORD_NUMBERING_UPDATED_SUCCESSFULLY_FOR') + " " + editViewForm.find('option[value="' + sourceModule + '"]').text()});
 				} else {
 					Settings_Vtiger_Index_Js.showMessage(data.error.message);
 				}

--- a/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
+++ b/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
@@ -63,7 +63,7 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 			sequenceNumberElement.validationEngine('showPrompt', app.vtranslate('JS_SEQUENCE_NUMBER_MESSAGE') + " " + oldSequenceNumber, 'error', 'topLeft', true);
 			return;
 		}
-		$('.saveButton').attr("disabled", "disabled");
+		editViewForm.find('.saveButton').attr("disabled", "disabled");
 		AppConnector.request({
 			'module': app.getModuleName(),
 			'parent': app.getParentModuleName(),
@@ -140,46 +140,47 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 		const value = editViewForm.find('[name="reset_sequence"]').val();
 		const prefix = editViewForm.find('[name="prefix"]').val();
 		const postfix = editViewForm.find('[name="postfix"]').val();
+		const saveBtn = editViewForm.find('.saveButton');
 		switch (value) {
 			case 'Y':
 				if (prefix.indexOf('{{YY}}') === -1 && prefix.indexOf('{{YYYY}}') === -1 && postfix.indexOf('{{YY}}') === -1 && postfix.indexOf('{{YYYY}}') === -1) {
-					$('.saveButton').attr('disabled', 'disabled');
+					saveBtn.attr('disabled', 'disabled');
 					Vtiger_Helper_Js.showMessage({
 						type: 'error',
 						text: app.vtranslate('JS_RS_ADD_YEAR_VARIABLE')
 					});
 				} else {
-					$('.saveButton').removeAttr('disabled');
+					saveBtn.removeAttr('disabled');
 					sequenceExists = true;
 				}
 				break;
 			case 'M':
 				if (prefix.indexOf('{{MM}}') === -1 && prefix.indexOf('{{M}}') === -1 && postfix.indexOf('{{MM}}') === -1 && postfix.indexOf('{{M}}') === -1) {
-					$('.saveButton').attr('disabled', 'disabled');
+					saveBtn.attr('disabled', 'disabled');
 					Vtiger_Helper_Js.showMessage({
 						type: 'error',
 						text: app.vtranslate('JS_RS_ADD_MONTH_VARIABLE')
 					});
 				} else {
-					$('.saveButton').removeAttr('disabled');
+					saveBtn.removeAttr('disabled');
 					sequenceExists = true;
 				}
 				break;
 			case 'D':
 				if (prefix.indexOf('{{DD}}') === -1 && prefix.indexOf('{{D}}') === -1 && postfix.indexOf('{{DD}}') === -1 && postfix.indexOf('{{D}}') === -1) {
-					$('.saveButton').attr('disabled', 'disabled');
+					saveBtn.attr('disabled', 'disabled');
 					Vtiger_Helper_Js.showMessage({
 						type: 'error',
 						text: app.vtranslate('JS_RS_ADD_DAY_VARIABLE')
 					});
 				} else {
-					$('.saveButton').removeAttr('disabled');
+					saveBtn.removeAttr('disabled');
 					sequenceExists = true;
 				}
 				break;
 			case 'X':
 			default:
-				$('.saveButton').removeAttr('disabled');
+				saveBtn.removeAttr('disabled');
 				sequenceExists = true;
 				break;
 		}

--- a/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
+++ b/public_html/layouts/basic/modules/Settings/Vtiger/resources/CustomRecordNumbering.js
@@ -21,7 +21,7 @@ jQuery.Class('Settings_CustomRecordNumbering_Js', {}, {
 	/**
 	 * Function to register change event for source module field
 	 */
-	registerOnChangeEventOfSourceModule: function () {
+	registerOnChangeEventOfSourceModule() {
 		const editViewForm = this.getForm();
 		editViewForm.find('[name="sourceModule"]').on('change', function (e) {
 			$('.saveButton').removeAttr('disabled');

--- a/tests/Entity/Z_ResetingRecordNumber.php
+++ b/tests/Entity/Z_ResetingRecordNumber.php
@@ -47,6 +47,14 @@ class RecordNumber extends \App\Fields\RecordNumber
 	 */
 	public static $currentDateIndex = 0;
 
+	/**
+	 * Date method mock for testing purposes.
+	 *
+	 * @param string   $format
+	 * @param null|int $time
+	 *
+	 * @return false|string
+	 */
 	public static function date($format, $time = null)
 	{
 		if (!isset(self::$dates[self::$currentDateIndex])) {
@@ -73,7 +81,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 	}
 
 	/**
-	 * @codeCoverageIgnore
+	 * Test method "DateMock".
 	 */
 	public function testDateMock()
 	{
@@ -168,7 +176,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 			}
 			$this->assertSame("$date/$currentNumber", RecordNumber::incrementNumber(95));
 			$number = RecordNumber::getNumber(95);
-			$this->assertSame($currentNumber+1, $number['sequenceNumber']);
+			$this->assertSame($currentNumber + 1, $number['sequenceNumber']);
 			$this->assertSame($resetSequence, $number['reset_sequence']);
 			$this->assertSame($sequence, $number['cur_sequence']);
 			$this->assertSame($prefix, $number['prefix']);

--- a/tests/Entity/Z_ResetingRecordNumber.php
+++ b/tests/Entity/Z_ResetingRecordNumber.php
@@ -67,6 +67,8 @@ class RecordNumber extends \App\Fields\RecordNumber
 class Z_ResetingRecordNumber extends \Tests\Base
 {
 	/**
+	 * Database transaction pointer.
+	 *
 	 * @var \yii\db\Transaction
 	 */
 	private static $transaction;
@@ -85,7 +87,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 	 */
 	public function testDateMock()
 	{
-		$this->assertSame(20, count(RecordNumber::$dates));
+		$this->assertCount(20, RecordNumber::$dates);
 		foreach (RecordNumber::$dates as $index => $date) {
 			RecordNumber::$currentDateIndex = $index;
 			$this->assertSame($date, RecordNumber::date('Y-m-d'));
@@ -111,7 +113,8 @@ class Z_ResetingRecordNumber extends \Tests\Base
 	 */
 	public function testIncrementNumberStandard()
 	{
-		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->queryOne();
+		RecordNumber::setNumber(95, 'F-I', 1, '', null, '');
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => 95])->one();
 		$this->assertSame('F-I', $originalRow['prefix']);
 		$this->assertSame('', $originalRow['postfix']);
 		$this->assertSame(null, $originalRow['reset_sequence']);
@@ -131,6 +134,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 
 	/**
 	 * Test method "Parse".
+	 * Test parsing method for record numbers on different dates.
 	 */
 	public function testParse()
 	{
@@ -145,6 +149,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 
 	/**
 	 * Test method "IncrementNumberDay".
+	 * Test record number resetting with new day.
 	 */
 	public function testIncrementNumberDay()
 	{
@@ -156,7 +161,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 		$curSequence = ($parts[0] . $parts[1] . $parts[2]);
 		$result = RecordNumber::setNumber(95, $prefix, $actualNumber, $postfix, $resetSequence, $curSequence);
 		$this->assertSame(1, $result);
-		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->noCache()->queryOne();
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => 95])->one();
 		$this->assertSame($prefix, $originalRow['prefix']);
 		$this->assertSame($postfix, $originalRow['postfix']);
 		$this->assertSame($resetSequence, $originalRow['reset_sequence']);
@@ -167,7 +172,6 @@ class Z_ResetingRecordNumber extends \Tests\Base
 		foreach (RecordNumber::$dates as $index => $date) {
 			RecordNumber::$currentDateIndex = $index;
 			$sequence = str_replace('-', '', $date);
-			$parts = explode('-', $date);
 			if ($sequence === $currentDate) {
 				$currentNumber++;
 			} else {
@@ -186,10 +190,10 @@ class Z_ResetingRecordNumber extends \Tests\Base
 
 	/**
 	 * Test method "IncrementNumberMonth".
+	 * Test record number resetting with new month.
 	 */
 	public function testIncrementNumberMonth()
 	{
-		$parts = explode('-', RecordNumber::$dates[0]);
 		$actualNumber = 1;
 		$prefix = '{{YYYY}}-{{MM}}-{{DD}}/';
 		$postfix = '';
@@ -197,7 +201,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 		$curSequence = '';
 		$result = RecordNumber::setNumber(95, $prefix, $actualNumber, $postfix, $resetSequence, $curSequence);
 		$this->assertSame(1, $result);
-		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->noCache()->queryOne();
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => 95])->one();
 		$this->assertSame($prefix, $originalRow['prefix']);
 		$this->assertSame($postfix, $originalRow['postfix']);
 		$this->assertSame($resetSequence, $originalRow['reset_sequence']);
@@ -227,6 +231,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 
 	/**
 	 * Test method "IncrementNumberYear".
+	 * Test record number resetting with new year.
 	 */
 	public function testIncrementNumberYear()
 	{
@@ -237,7 +242,7 @@ class Z_ResetingRecordNumber extends \Tests\Base
 		$curSequence = '';
 		$result = RecordNumber::setNumber(95, $prefix, $actualNumber, $postfix, $resetSequence, $curSequence);
 		$this->assertSame(1, $result);
-		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->noCache()->queryOne();
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['tabid' => 95])->one();
 		$this->assertSame($prefix, $originalRow['prefix']);
 		$this->assertSame($postfix, $originalRow['postfix']);
 		$this->assertSame($resetSequence, $originalRow['reset_sequence']);

--- a/tests/Entity/Z_ResetingRecordNumber.php
+++ b/tests/Entity/Z_ResetingRecordNumber.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Reseting record number test class.
+ *
+ * @copyright YetiForce Sp. z o.o
+ * @license   YetiForce Public License 3.0 (licenses/LicenseEN.txt or yetiforce.com)
+ * @author    Rafal Pospiech <r.pospiech@yetiforce.com>
+ */
+
+namespace Tests\Entity;
+
+/**
+ * Class RecordNumber.
+ *
+ * @codeCoverageIgnore
+ */
+class RecordNumber extends \App\Fields\RecordNumber
+{
+	/**
+	 * @var array of dates
+	 */
+	public static $dates = [
+		'2015-01-01',
+		'2015-03-03',
+		'2015-03-03',
+		'2015-03-03',
+		'2015-03-04',
+		'2015-03-04',
+		'2015-03-05',
+		'2015-11-09',
+		'2015-11-10',
+		'2015-11-11',
+		'2015-11-28',
+		'2016-11-29',
+		'2017-03-15',
+		'2017-03-18',
+		'2017-07-19',
+		'2018-01-01',
+		'2018-01-02',
+		'2018-01-02',
+		'2018-02-03',
+		'2018-05-05'
+	];
+
+	/**
+	 * @var int
+	 */
+	public static $currentDateIndex = 0;
+
+	public static function date($format, $time = null)
+	{
+		if (!isset(self::$dates[self::$currentDateIndex])) {
+			self::$currentDateIndex = 0;
+		}
+		return date($format, strtotime(self::$dates[self::$currentDateIndex]));
+	}
+}
+
+class Z_ResetingRecordNumber extends \Tests\Base
+{
+	/**
+	 * @var \yii\db\Transaction
+	 */
+	private static $transaction;
+
+	/**
+	 * @codeCoverageIgnore
+	 * Setting of tests.
+	 */
+	public static function setUpBeforeClass()
+	{
+		static::$transaction = \App\Db::getInstance()->beginTransaction();
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function testDateMock()
+	{
+		$this->assertSame(20, count(RecordNumber::$dates));
+		foreach (RecordNumber::$dates as $index => $date) {
+			RecordNumber::$currentDateIndex = $index;
+			$this->assertSame($date, RecordNumber::date('Y-m-d'));
+		}
+	}
+
+	/**
+	 * Test method "StandardNumber".
+	 */
+	public function testSequenceNumber()
+	{
+		foreach (RecordNumber::$dates as $index => $date) {
+			RecordNumber::$currentDateIndex = $index;
+			$parts = explode('-', $date);
+			$this->assertSame($parts[0], RecordNumber::getSequenceNumber('Y'));
+			$this->assertSame($parts[0] . $parts[1], RecordNumber::getSequenceNumber('M'));
+			$this->assertSame($parts[0] . $parts[1] . $parts[2], RecordNumber::getSequenceNumber('D'));
+		}
+	}
+
+	/**
+	 * Test method "IncrementNumberStandard".
+	 */
+	public function testIncrementNumberStandard()
+	{
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->queryOne();
+		$this->assertSame('F-I', $originalRow['prefix']);
+		$this->assertSame('', $originalRow['postfix']);
+		$this->assertSame(null, $originalRow['reset_sequence']);
+		$this->assertSame('', $originalRow['cur_sequence']);
+		$actualNumber = $originalRow['cur_id'];
+		foreach (RecordNumber::$dates as $index => $date) {
+			$this->assertSame("F-I$actualNumber", RecordNumber::incrementNumber(95));
+			$actualNumber++;
+			$number = RecordNumber::getNumber(95, false);
+			$this->assertSame($actualNumber, $number['sequenceNumber']);
+			$this->assertSame(null, $number['reset_sequence']);
+			$this->assertSame('', $number['cur_sequence']);
+			$this->assertSame('F-I', $number['prefix']);
+			$this->assertSame('', $number['postfix']);
+		}
+	}
+
+	/**
+	 * Test method "Parse".
+	 */
+	public function testParse()
+	{
+		foreach (RecordNumber::$dates as $index => $date) {
+			RecordNumber::$currentDateIndex = $index;
+			$parts = explode('-', $date);
+			$this->assertSame($parts[2] . '/1', RecordNumber::parse('{{DD}}/', 1, ''));
+			$this->assertSame($parts[1] . '/1', RecordNumber::parse('{{MM}}/', 1, ''));
+			$this->assertSame($parts[0] . '/1', RecordNumber::parse('{{YYYY}}/', 1, ''));
+		}
+	}
+
+	/**
+	 * Test method "IncrementNumberDay".
+	 */
+	public function testIncrementNumberDay()
+	{
+		$parts = explode('-', RecordNumber::$dates[0]);
+		$actualNumber = 1;
+		$prefix = '{{YYYY}}-{{MM}}-{{DD}}/';
+		$postfix = '';
+		$resetSequence = 'D';
+		$curSequence = ($parts[0] . $parts[1] . $parts[2]);
+		$result = RecordNumber::setNumber(95, $prefix, $actualNumber, $postfix, $resetSequence, $curSequence);
+		$this->assertSame(1, $result);
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->noCache()->queryOne();
+		$this->assertSame($prefix, $originalRow['prefix']);
+		$this->assertSame($postfix, $originalRow['postfix']);
+		$this->assertSame($resetSequence, $originalRow['reset_sequence']);
+		$this->assertSame($curSequence, $originalRow['cur_sequence']);
+		$this->assertSame($actualNumber, $originalRow['cur_id']);
+		$currentNumber = 1;
+		$currentDate = '';
+		foreach (RecordNumber::$dates as $index => $date) {
+			RecordNumber::$currentDateIndex = $index;
+			$sequence = str_replace('-', '', $date);
+			$parts = explode('-', $date);
+			if ($sequence === $currentDate) {
+				$currentNumber++;
+			} else {
+				$currentNumber = 1;
+				$currentDate = $sequence;
+			}
+			$this->assertSame("$date/$currentNumber", RecordNumber::incrementNumber(95));
+			$number = RecordNumber::getNumber(95);
+			$this->assertSame($currentNumber+1, $number['sequenceNumber']);
+			$this->assertSame($resetSequence, $number['reset_sequence']);
+			$this->assertSame($sequence, $number['cur_sequence']);
+			$this->assertSame($prefix, $number['prefix']);
+			$this->assertSame($postfix, $number['postfix']);
+		}
+	}
+
+	/**
+	 * Test method "IncrementNumberMonth".
+	 */
+	public function testIncrementNumberMonth()
+	{
+		$parts = explode('-', RecordNumber::$dates[0]);
+		$actualNumber = 1;
+		$prefix = '{{YYYY}}-{{MM}}-{{DD}}/';
+		$postfix = '';
+		$resetSequence = 'M';
+		$curSequence = '';
+		$result = RecordNumber::setNumber(95, $prefix, $actualNumber, $postfix, $resetSequence, $curSequence);
+		$this->assertSame(1, $result);
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->noCache()->queryOne();
+		$this->assertSame($prefix, $originalRow['prefix']);
+		$this->assertSame($postfix, $originalRow['postfix']);
+		$this->assertSame($resetSequence, $originalRow['reset_sequence']);
+		$this->assertSame($curSequence, $originalRow['cur_sequence']);
+		$this->assertSame($actualNumber, $originalRow['cur_id']);
+		$currentNumber = 1;
+		$currentDate = '';
+		foreach (RecordNumber::$dates as $index => $date) {
+			RecordNumber::$currentDateIndex = $index;
+			$parts = explode('-', $date);
+			$sequence = $parts[0] . $parts[1];
+			if ($sequence === $currentDate) {
+				$currentNumber++;
+			} else {
+				$currentNumber = 1;
+				$currentDate = $sequence;
+			}
+			$this->assertSame("$date/$currentNumber", RecordNumber::incrementNumber(95));
+			$number = RecordNumber::getNumber(95);
+			$this->assertSame($currentNumber + 1, $number['sequenceNumber']);
+			$this->assertSame($resetSequence, $number['reset_sequence']);
+			$this->assertSame($sequence, $number['cur_sequence']);
+			$this->assertSame($prefix, $number['prefix']);
+			$this->assertSame($postfix, $number['postfix']);
+		}
+	}
+
+	/**
+	 * Test method "IncrementNumberYear".
+	 */
+	public function testIncrementNumberYear()
+	{
+		$actualNumber = 1;
+		$prefix = '{{YYYY}}-{{MM}}-{{DD}}/';
+		$postfix = '';
+		$resetSequence = 'Y';
+		$curSequence = '';
+		$result = RecordNumber::setNumber(95, $prefix, $actualNumber, $postfix, $resetSequence, $curSequence);
+		$this->assertSame(1, $result);
+		$originalRow = (new \App\Db\Query())->from('vtiger_modentity_num')->where(['=', 'tabid', 95])->createCommand()->noCache()->queryOne();
+		$this->assertSame($prefix, $originalRow['prefix']);
+		$this->assertSame($postfix, $originalRow['postfix']);
+		$this->assertSame($resetSequence, $originalRow['reset_sequence']);
+		$this->assertSame($curSequence, $originalRow['cur_sequence']);
+		$this->assertSame($actualNumber, $originalRow['cur_id']);
+		$currentNumber = 1;
+		$currentDate = '';
+		foreach (RecordNumber::$dates as $index => $date) {
+			RecordNumber::$currentDateIndex = $index;
+			$parts = explode('-', $date);
+			$sequence = $parts[0];
+			if ($sequence === $currentDate) {
+				$currentNumber++;
+			} else {
+				$currentNumber = 1;
+				$currentDate = $sequence;
+			}
+			$this->assertSame("$date/$currentNumber", RecordNumber::incrementNumber(95));
+			$number = RecordNumber::getNumber(95);
+			$this->assertSame($currentNumber + 1, $number['sequenceNumber']);
+			$this->assertSame($resetSequence, $number['reset_sequence']);
+			$this->assertSame($sequence, $number['cur_sequence']);
+			$this->assertSame($prefix, $number['prefix']);
+			$this->assertSame($postfix, $number['postfix']);
+		}
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * Cleaning after tests.
+	 */
+	public static function tearDownAfterClass()
+	{
+		static::$transaction->rollBack();
+		\App\Cache::clear();
+	}
+}


### PR DESCRIPTION
![chrome_2018-08-08_11-57-44](https://user-images.githubusercontent.com/36499752/43830734-56965662-9b02-11e8-83a2-46844810c7ea.jpg)

## reset record number when specified date parameter change

### When reset sequence is set to day ('D') then each day number will reset and start with 1.
'2016-08-02' => 1
'2016-08-02' => 2
'2016-08-02' => 3
'2016-08-03' => 1
'2016-08-03' => 2
'2016-08-03' => 3
...

### When reset sequence is set to month ('M')
'2016-08-03' => 1
'2016-08-03' => 2
'2016-08-03' => 3
'2016-08-04' => 4
'2016-08-04' => 5
'2016-08-06' => 6
'2016-09-03' => 1
'2016-09-03' => 2
...

### When reset sequence is set to year ('Y')
'2016-08-03' => 1
'2016-08-03' => 2
'2016-08-03' => 3
'2016-09-07' => 4
'2016-10-03' => 5
'2017-08-03' => 1
...

If reset sequence is set to some period, this period must be present in prefix in some form.
For example for month period reset sequence ('M'), prefix must contain {{MM}} or {{M}} to prevent duplicate numbering (no period prefix 1,2,3 will give same numbers after reset  1,2,3).

## added leading zeros in record number
like (prefix) `F{{0}}{{0}}{{0}}{{0}}` => `F00001`  (output number)
When record number will have more digits than leading zeros - it will still work but it will not have leading zeros any more.
