### PR TITLE
Fix undefined events by date in Calendar/QuickCreateEvents.tpl

### DIFF
--- a/layouts/basic/modules/Calendar/QuickCreateEvents.tpl
+++ b/layouts/basic/modules/Calendar/QuickCreateEvents.tpl
@@ -1,7 +1,8 @@
 {*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 {strip}
 	{foreach from=$DATES item=DATE name="iteration"}
-		<div class="col float-left px-0 small font-weight-bold" {if $smarty.foreach.iteration.index eq 3}id="cur_events"{/if}>
+		<div class="col float-left px-0 small font-weight-bold"
+			 {if $smarty.foreach.iteration.index eq 3}id="cur_events"{/if}>
 			<table class="table">
 				<tr>
 					{if $smarty.foreach.iteration.first}
@@ -10,7 +11,10 @@
 						</th>
 					{/if}
 					<th class="text-center col-md-2 taskPrevTwoDaysAgo">
-						<span class="u-cursor-pointer dateBtn" data-date="{App\Fields\Date::formatToDisplay($DATE)}">{App\Fields\Date::formatToDisplay($DATE)}&nbsp;({\App\Language::translate('LBL_'|cat:\App\Fields\Date::getDayFromDate($DATE, true), $MODULE_NAME)})</span>
+						<span class="u-cursor-pointer dateBtn"
+							  data-date="{App\Fields\Date::formatToDisplay($DATE)}">{App\Fields\Date::formatToDisplay($DATE)}
+							&nbsp;({\App\Language::translate('LBL_'|cat:\App\Fields\Date::getDayFromDate($DATE, true), $MODULE_NAME)}
+							)</span>
 					</th>
 					{if $smarty.foreach.iteration.last}
 						<th class="p-1 d-none d-md-table-cell">
@@ -18,15 +22,16 @@
 						</th>
 					{/if}
 				</tr>
-				{foreach from=$EVENTS[$DATE] item=EVENT}
-					<tr class="mode_{$EVENT['set']} addedNearCalendarEvent">
-						<td colspan="{if $smarty.foreach.iteration.last || $smarty.foreach.iteration.first}2{else}{/if}">
-							<a target="_blank" href="{$EVENT['url']}">
-								<div class="cut-string">
-									<span class="fas fa-calendar-alt"></span>
-									<span class="px-1"><strong>{$EVENT['hour_start']}</strong></span>
+				{if !empty($EVENTS[$DATE])}
+					{foreach from=$EVENTS[$DATE] item=EVENT}
+						<tr class="mode_{$EVENT['set']} addedNearCalendarEvent">
+							<td colspan="{if $smarty.foreach.iteration.last || $smarty.foreach.iteration.first}2{else}{/if}">
+								<a target="_blank" href="{$EVENT['url']}">
+									<div class="cut-string">
+										<span class="fas fa-calendar-alt"></span>
+										<span class="px-1"><strong>{$EVENT['hour_start']}</strong></span>
 										<span>{App\TextParser::textTruncate($EVENT['title'], 16)}</span>
-									<span class="js-help-info" title="" data-placement="top" data-content="
+										<span class="js-help-info" title="" data-placement="top" data-content="
 										  <div><label class='px-1'>{App\Language::translate('Start Time', $MODULE_NAME)}:</label>{$EVENT['start_display']}</div>
 										  <div><label class='px-1'>{App\Language::translate('End Time', $MODULE_NAME)}:</label>{$EVENT['end_display']}</div>
 										  <div><label class='px-1'>{App\Language::translate('Subject', $MODULE_NAME)}:</label>{\App\Purifier::encodeHtml($EVENT['title'])}</div>
@@ -45,17 +50,18 @@
 										">
 										<i class="float-right fas fa-info-circle"></i>
 									</span>
-								</div>
-							</a>
-							{if $SHOW_COMPANIES}
-								<div class="cut-string">
-									<span class="calIcon userIcon-{$EVENT['linkm']}"></span> 
-									{$EVENT['linkl']}
-								</div>
-							{/if}
-						</td>
-					</tr>
-				{/foreach}
+									</div>
+								</a>
+								{if $SHOW_COMPANIES}
+									<div class="cut-string">
+										<span class="calIcon userIcon-{$EVENT['linkm']}"></span>
+										{$EVENT['linkl']}
+									</div>
+								{/if}
+							</td>
+						</tr>
+					{/foreach}
+				{/if}
 			</table>
 		</div>
 	{/foreach}


### PR DESCRIPTION
Add line 25, {if !empty($EVENTS[$DATE])}
![przechwytywanie](https://user-images.githubusercontent.com/11301300/44456766-b6643a00-a601-11e8-9c31-aa96c6b5bcc1.PNG)
