### PR TITLE
Fix scrutinizer: "The expression $modulename of type null|string is loosely compared to true"

### DIFF
--- a/vtlib/Vtiger/PackageImport.php
+++ b/vtlib/Vtiger/PackageImport.php
@@ -336,7 +336,7 @@ class PackageImport extends PackageExport
 			$validzip = false;
 			$this->_errorText = \App\Language::translate('LBL_ERROR_NO_VALID_PREFIX', 'Settings:ModuleManager');
 		}
-		if ($manifestxml_found && !empty($this->_modulexml->type) && in_array(strtolower($this->_modulexml->type), ['entity', 'inventory', 'extension']) && $modulename && \Settings_ModuleManager_Module_Model::checkModuleName($modulename)) {
+		if ($manifestxml_found && null !== $modulename && !empty($this->_modulexml->type) && \Settings_ModuleManager_Module_Model::checkModuleName($modulename) && \in_array(strtolower($this->_modulexml->type), ['entity', 'inventory', 'extension'])) {
 			$validzip = false;
 			$this->_errorText = \App\Language::translate('LBL_INVALID_MODULE_NAME', 'Settings:ModuleManager');
 		}

--- a/vtlib/Vtiger/PackageImport.php
+++ b/vtlib/Vtiger/PackageImport.php
@@ -336,7 +336,7 @@ class PackageImport extends PackageExport
 			$validzip = false;
 			$this->_errorText = \App\Language::translate('LBL_ERROR_NO_VALID_PREFIX', 'Settings:ModuleManager');
 		}
-		if ($manifestxml_found && null !== $modulename && !empty($this->_modulexml->type) && \Settings_ModuleManager_Module_Model::checkModuleName($modulename) && \in_array(strtolower($this->_modulexml->type), ['entity', 'inventory', 'extension'])) {
+		if ($manifestxml_found && !empty($modulename) && !empty($this->_modulexml->type) && \Settings_ModuleManager_Module_Model::checkModuleName($modulename) && \in_array(strtolower($this->_modulexml->type), ['entity', 'inventory', 'extension'])) {
 			$validzip = false;
 			$this->_errorText = \App\Language::translate('LBL_INVALID_MODULE_NAME', 'Settings:ModuleManager');
 		}


### PR DESCRIPTION
Fix scrutinizer: "The expression $modulename of type null|string is loosely compared to true"