### PR TITLE
Fix clockpicker and datepicker when input is in readonly state on calendar

### DIFF
--- a/public_html/layouts/basic/modules/Calendar/resources/Edit.js
+++ b/public_html/layouts/basic/modules/Calendar/resources/Edit.js
@@ -329,18 +329,20 @@ Vtiger_Edit_Js("Calendar_Edit_Js", {}, {
 		});
 	},
 	registerAutoFillHours: function (container) {
-		var thisInstance = this;
-		var allDay = container.find('[name="allday"]');
-		var timeStart = container.find('[name="time_start"]');
-		var timeEnd = container.find('[name="time_end"]');
-		var dateEnd = container.find('[name="due_date"]');
+		const thisInstance = this;
+		let allDay = container.find('[name="allday"]'),
+			timeStart = container.find('[name="time_start"]'),
+			timeEnd = container.find('[name="time_end"]'),
+			dateEnd = container.find('[name="due_date"]');
 		container.find('.js-autofill').on('change', function (e) {
-			var currentTarget = $(e.currentTarget);
+			let currentTarget = $(e.currentTarget);
 			if (currentTarget.is(':checked')) {
 				container.find('.js-autofill').prop('checked', true);
 				thisInstance.getFreeTime(container);
 				timeStart.attr('readonly', 'readonly');
 				timeEnd.attr('readonly', 'readonly');
+				timeStart.clockpicker('remove');
+				timeEnd.clockpicker('remove');
 				allDay.attr('disabled', 'disabled');
 				allDay.prop('checked', false);
 				allDay.trigger('change');
@@ -351,6 +353,8 @@ Vtiger_Edit_Js("Calendar_Edit_Js", {}, {
 				timeStart.removeAttr('readonly');
 				timeEnd.removeAttr('readonly');
 				dateEnd.removeAttr('readonly');
+				app.registerEventForClockPicker(timeStart);
+				app.registerEventForClockPicker(timeEnd);
 			}
 		});
 	},

--- a/public_html/layouts/resources/Fields.js
+++ b/public_html/layouts/resources/Fields.js
@@ -68,7 +68,8 @@ App.Fields = {
 				weekStart: CONFIG.firstDayOfWeekNo,
 				autoclose: true,
 				todayHighlight: true,
-				format: format
+				format: format,
+				enableOnReadonly: false
 			};
 			if (typeof customParams !== "undefined") {
 				params = $.extend(params, customParams);


### PR DESCRIPTION
Fix clockpicker and datepicker when input is in readonly state on calendar
![bug-calendar-date](https://user-images.githubusercontent.com/39482453/47136393-dfc4dd80-d2b3-11e8-965d-4d40ec48efeb.png)
