### PR TITLE
YetiForcePDF update 0.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "yetiforce/debugbar": "^1.13.1.1",
     "yetiforce/yii2": "2.0.15.3",
     "yetiforce/icalendar": "^1.0.2",
-    "yetiforce/yetiforcepdf": "^0.1.3"
+    "yetiforce/yetiforcepdf": "^0.1.5"
   },
   "require-dev": {
     "facebook/webdriver": "^1.6.0",


### PR DESCRIPTION
Do not throw errors when font file is missing, use default one instead.