### PR TITLE
gantt min height bugfix (in lower resolutions we wan't be able to work) [IT415]

### DIFF
--- a/public_html/layouts/basic/modules/Project/resources/Gantt.js
+++ b/public_html/layouts/basic/modules/Project/resources/Gantt.js
@@ -205,8 +205,8 @@ class Gantt {
 		let offsetTop = this.container.offset().top;
 		let contentHeight = $('body').eq(0).height() - $('.js-footer').eq(0).height();
 		let height = contentHeight - offsetTop - 100;
-		if (height < 0) {
-			height = 0;
+		if (height < 300) {
+			height = 300;
 		}
 		this.options.maxHeight = height;
 		if (typeof this.ganttState !== 'undefined' && this.ganttState) {


### PR DESCRIPTION
### before we can't scroll below
![image](https://user-images.githubusercontent.com/36499752/52570435-b0fae600-2e13-11e9-9619-3d373af52857.png)

### now
![chrome_2019-02-11_15-39-28](https://user-images.githubusercontent.com/36499752/52570412-a50f2400-2e13-11e9-86e0-447c0e46f943.jpg)
