### PR TITLE
Fixed "Call to member function regenerateId() on null"

### DIFF
--- a/app/Session.php
+++ b/app/Session.php
@@ -106,8 +106,9 @@ class Session
 	{
 		if (empty(static::$pool)) {
 			\session_regenerate_id($deleteOldSession);
+		} else {
+			static::$pool->regenerateId($deleteOldSession);
 		}
-		static::$pool->regenerateId($deleteOldSession);
 	}
 
 	/**


### PR DESCRIPTION
Fixed "Call to member function regenerateId() on null"
![firefox_2019-02-28_13-39-01](https://user-images.githubusercontent.com/32322851/53567243-ecf5b100-3b5e-11e9-9bba-690b2cff1a3f.png)
