### PR TITLE
YetiForcePDF update v0.1.19 (basic css class support!)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "yetiforce/csrf-magic": "^v1.0.8",
     "yetiforce/debugbar": "^1.13.1.1",
     "yetiforce/yii2": "2.0.15.3",
-    "yetiforce/yetiforcepdf": "0.1.18",
+    "yetiforce/yetiforcepdf": "0.1.19",
     "abraham/twitteroauth": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Initial class attributes support!
For now just single classes inside `<style>` tag and multiple inside element attribute.
```html
<style>
.red{ background-color: #ff0000; }
.green{ background-color: #00ff00;}
</style>
<div class="red">red bg</div>
<div class="red green">green bg</div>
```