### PR TITLE
YetiForcePDF update v0.1.20, watermark_text as text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "yetiforce/csrf-magic": "^v1.0.8",
     "yetiforce/debugbar": "^1.13.1.1",
     "yetiforce/yii2": "2.0.15.3",
-    "yetiforce/yetiforcepdf": "0.1.18",
+    "yetiforce/yetiforcepdf": "0.1.20",
     "abraham/twitteroauth": "^1.0"
   },
   "require-dev": {

--- a/install/install_schema/scheme.sql
+++ b/install/install_schema/scheme.sql
@@ -149,7 +149,7 @@ CREATE TABLE `a_yf_pdf` (
   `default` tinyint(1) DEFAULT NULL,
   `conditions` text DEFAULT NULL,
   `watermark_type` tinyint(1) NOT NULL DEFAULT 0,
-  `watermark_text` varchar(255) NOT NULL,
+  `watermark_text` text NOT NULL,
   `watermark_angle` smallint(3) unsigned NOT NULL,
   `watermark_image` varchar(255) NOT NULL,
   `template_members` text NOT NULL,


### PR DESCRIPTION
watermark_text is now TEXT instead of varchar(255)