### PR TITLE
Bug with filters in Workflows

### DIFF
--- a/layouts/basic/modules/Vtiger/AdvanceFilter.tpl
+++ b/layouts/basic/modules/Vtiger/AdvanceFilter.tpl
@@ -95,7 +95,7 @@
 					{if !empty($ANY_CONDITION_CRITERIA['condition'])}
 						{assign var=GROUP_CONDITION value=$ANY_CONDITION_CRITERIA['condition']}
 					{else}
-						{assign var=GROUP_CONDITION value="and"}
+						{assign var=GROUP_CONDITION value="or"}
 					{/if}
 					<input type="hidden" name="condition" value="{$GROUP_CONDITION}"/>
 				</div>

--- a/public_html/layouts/basic/modules/Settings/Workflows/resources/AdvanceFilter.js
+++ b/public_html/layouts/basic/modules/Settings/Workflows/resources/AdvanceFilter.js
@@ -223,7 +223,7 @@ Vtiger_AdvanceFilter_Js(
 					values[index + 1]['columns'] = iterationValues;
 				}
 				if (groupElement.find('div.groupCondition').length > 0) {
-					values[index + 1]['condition'] = conditionGroups.find('div.groupCondition [name="condition"]').val();
+					values[index + 1]['condition'] = groupElement.find('div.groupCondition [name="condition"]').val();
 				}
 			});
 			return values;


### PR DESCRIPTION
## Description
Bug when adding "or" conditions in workflows. Before correction, it was stored in the database as "and" conditions.

![Screenshot_1](https://user-images.githubusercontent.com/16593721/64511749-d9c95800-d2dc-11e9-8239-ebb01c7fb261.png)


## Testing
<!--- Please describe in detail how to test your changes. -->
Create a filter with more than one condition in "Any conditions" group. It works like an "and" condition before this changes and works properly after.

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [x] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
