### PR TITLE
Snenko hide top menu items

### DIFF
--- a/layouts/basic/modules/Vtiger/menu/Label.tpl
+++ b/layouts/basic/modules/Vtiger/menu/Label.tpl
@@ -6,6 +6,14 @@
 	{else}
 		{assign var=ACTIVE value='false'}
 	{/if}
+
+	{if $MENU_MODULE=='Settings::Vtiger'}
+		{assign var=SHOWITEMMENU value='true'}
+	{else}
+		{assign var=SHOWITEMMENU value=Vtiger_Menu_Model::isShowTopLevelMenuItem($MENU, $MENU_MODULE)}
+	{/if}
+
+	{if $SHOWITEMMENU=='true'}
 	<li class="tpl-menu-Label c-menu__item js-menu__item nav-item menuLabel {if !$HASCHILDS}hasParentMenu{/if}" data-id="{$MENU['id']}"
 		data-js="mouseenter mouseleave">
 		<a class="nav-link {if $ACTIVE=='true'}active{else}collapsed{/if}{if $ICON} hasIcon{/if}{if $HASCHILDS == 'true'} js-submenu-toggler is-submenu-toggler{/if}" href="#"
@@ -18,4 +26,5 @@
 		</a>
 		{include file=\App\Layout::getTemplatePath('menu/SubMenu.tpl', $MODULE)}
 	</li>
+	{/if}
 {/strip}

--- a/modules/Vtiger/models/Menu.php
+++ b/modules/Vtiger/models/Menu.php
@@ -218,4 +218,31 @@ class Vtiger_Menu_Model
 		}
 		return '';
 	}
+
+    /**
+     * @param $menu
+     *
+     * @return bool
+     */
+    public static function isShowTopLevelMenuItem($menu)
+    {
+        if(isset($menu['childs']) && count($menu['childs'])>0) {
+            foreach ($menu['childs'] as $id=>$subMenu) {
+
+                $privilegesModel = Users_Privileges_Model::getCurrentUserPrivilegesModel();
+                if(\App\Module::isModuleActive($subMenu['mod'])==false) {
+                    return false;
+                }
+
+                if ($privilegesModel->isAdminUser() ||
+                    $privilegesModel->hasGlobalReadPermission() ||
+                    $privilegesModel->hasModulePermission($subMenu['tabid']) ) {
+                    return true;
+                }
+
+            }
+        }
+
+        return true;
+    }
 }

--- a/modules/Vtiger/models/Menu.php
+++ b/modules/Vtiger/models/Menu.php
@@ -231,7 +231,7 @@ class Vtiger_Menu_Model
 
                 $privilegesModel = Users_Privileges_Model::getCurrentUserPrivilegesModel();
                 if(\App\Module::isModuleActive($subMenu['mod'])==false) {
-                    return false;
+                    continue;
                 }
 
                 if ($privilegesModel->isAdminUser() ||
@@ -241,6 +241,8 @@ class Vtiger_Menu_Model
                 }
 
             }
+
+            return false;
         }
 
         return true;


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
I hide the top menu items that a user cannot access

## Testing
Tested on my local computer and on my server with several employees.

## Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [ ] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.
