### PR TITLE
Corrected add class active to submenu

### DIFF
--- a/layouts/basic/modules/Vtiger/menu/Module.tpl
+++ b/layouts/basic/modules/Vtiger/menu/Module.tpl
@@ -2,7 +2,7 @@
 	{*<!-- {[The file is published on the basis of YetiForce Public License 3.0 that can be found in the following directory: licenses/LicenseEN.txt or yetiforce.com]} -->*}
 	{if \App\Module::isModuleActive($MENU['mod']) AND ($PRIVILEGESMODEL->isAdminUser() || $PRIVILEGESMODEL->hasGlobalReadPermission() || $PRIVILEGESMODEL->hasModulePermission($MENU['tabid']) ) }
 		{assign var=ICON value=Vtiger_Menu_Model::getMenuIcon($MENU, Vtiger_Menu_Model::vtranslateMenu($MENU['name'],$MENU['mod']))}
-		{if $MENU['name'] == $MODULE}
+		{if $MENU['mod'] === $MODULE}
 			{assign var=ACTIVE value='true'}
 		{else}
 			{assign var=ACTIVE value='false'}


### PR DESCRIPTION
An amendment has been made to give the menu item the active class, provided the module label name is different from the Basic module name