### PR TITLE
Add inventory Column name at the end of inventory listing

### DIFF
--- a/layouts/basic/modules/Vtiger/Detail/InventoryView.tpl
+++ b/layouts/basic/modules/Vtiger/Detail/InventoryView.tpl
@@ -62,6 +62,15 @@
 				<tfoot>
 				<tr>
 					{foreach item=FIELD from=$FIELDS[1]}
+						<th class="col{$FIELD->getType()} textAlignCenter {if !$FIELD->isSummary()}hideTd{/if}">
+							{if $FIELD->isSummary()}
+								{\App\Language::translate($FIELD->get('label'), $MODULE_NAME)}
+							{/if}
+						</th>
+					{/foreach}
+				</tr>
+				<tr>
+					{foreach item=FIELD from=$FIELDS[1]}
 						<td class="col{$FIELD->getType()} textAlignRight {if !$FIELD->isSummary()}hideTd{else}wisableTd{/if}"
 							data-sumfield="{lcfirst($FIELD->getType())}">
 							{if $FIELD->isSummary()}

--- a/layouts/basic/modules/Vtiger/Edit/Inventory.tpl
+++ b/layouts/basic/modules/Vtiger/Edit/Inventory.tpl
@@ -136,6 +136,18 @@
 					<td colspan="1" class="hideTd u-w-1per-45px">&nbsp;&nbsp;</td>
 					{foreach item=FIELD from=$FIELDS[1]}
 						<td {if !$FIELD->isEditable()}colspan="0"{/if}
+								class="col{$FIELD->getType()}{if !$FIELD->isEditable()} d-none{/if} text-center
+								{if !$FIELD->isSummary()} hideTd{/if}">
+							{if $FIELD->isSummary()}
+								{\App\Language::translate($FIELD->get('label'), $FIELD->getModuleName())}
+							{/if}
+						</td>
+					{/foreach}
+				</tr>
+				<tr>
+					<td colspan="1" class="hideTd u-w-1per-45px">&nbsp;&nbsp;</td>
+					{foreach item=FIELD from=$FIELDS[1]}
+						<td {if !$FIELD->isEditable()}colspan="0"{/if}
 							class="col{$FIELD->getType()}{if !$FIELD->isEditable()} d-none{/if} text-right
 								{if !$FIELD->isSummary()} hideTd{else} wisableTd{/if}"
 							data-sumfield="{lcfirst($FIELD->getType())}">


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description

I have seen is not clear when you use inventory and have a lot of lines, it's not clear wich column is at the end. 

For exemple : 

![image](https://user-images.githubusercontent.com/1949622/101763489-22268580-3adf-11eb-8bc1-a45f65804e5f.png)


## Testing

Just apply the diff and go inside an inventory module on edit and Detail view
You will seen on détail : 
![image](https://user-images.githubusercontent.com/1949622/101763631-54d07e00-3adf-11eb-8e52-fb4cd50ae7c4.png)


and on edit view : 

![image](https://user-images.githubusercontent.com/1949622/101763715-7598d380-3adf-11eb-9fdb-8932d6d4563a.png)


## Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [ ] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
