### PR TITLE
Fix pdf order

### DIFF
--- a/app/Pdf/YetiForcePDF.php
+++ b/app/Pdf/YetiForcePDF.php
@@ -477,8 +477,8 @@ class YetiForcePDF extends PDF
 	{
 		$html = $this->watermark ? $this->wrapWatermark($this->watermark) : '';
 		$html .= $this->header ? $this->wrapHeaderContent($this->header) : '';
-		$html .= $this->footer ? $this->wrapFooterContent($this->footer) : '';
 		$html .= $this->html;
+		$html .= $this->footer ? $this->wrapFooterContent($this->footer) : '';
 		return $html;
 	}
 


### PR DESCRIPTION
## Description
On pdf génération code, you write header, footer and, at the end, body. 

it's not logical because footer is after the body

## Testing
Generate pdf and now, footer is at the end, after the body

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [ x] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ x] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
