### PR TITLE
Set Correct validator Engine for inventory Fields

### DIFF
--- a/layouts/basic/modules/Vtiger/inventoryfields/EditViewDouble.tpl
+++ b/layouts/basic/modules/Vtiger/inventoryfields/EditViewDouble.tpl
@@ -9,6 +9,6 @@
 			{$FIELD->getDisplayValue($VALUE)}
 		</span>
 	{/if}
-	<input name="inventory[{$ROW_NO}][{$FIELD->getColumnName()}]" type="{$INPUT_TYPE}" class="form-control form-control-sm {$FIELD->getColumnName()} integerVal" data-validation-engine="validate[funcCall[Vtiger_NumberUserFormat_Validator_Js.invokeValidation],maxSize[{$FIELD->getRangeValues()}]]" value="{$FIELD->getEditValue($VALUE)}" {if $FIELD->isReadOnly()}readonly="readonly"{/if}/>
+	<input name="inventory[{$ROW_NO}][{$FIELD->getColumnName()}]" type="{$INPUT_TYPE}" class="form-control form-control-sm {$FIELD->getColumnName()} integerVal" data-validation-engine="validate[funcCall[Vtiger_Double_Validator_Js.invokeValidation],maxSize[{$FIELD->getRangeValues()}]]" value="{$FIELD->getEditValue($VALUE)}" {if $FIELD->isReadOnly()}readonly="readonly"{/if}/>
 	<!-- /tpl-Base-inventoryfields-EditViewDouble -->
 {/strip}

--- a/layouts/basic/modules/Vtiger/inventoryfields/EditViewInteger.tpl
+++ b/layouts/basic/modules/Vtiger/inventoryfields/EditViewInteger.tpl
@@ -9,6 +9,6 @@
 			{$FIELD->getDisplayValue($VALUE)}
 		</span>
 	{/if}
-	<input name="inventory[{$ROW_NO}][{$FIELD->getColumnName()}]" type="{$INPUT_TYPE}" class="form-control form-control-sm {$FIELD->getColumnName()} integerVal" data-validation-engine="validate[funcCall[Vtiger_WholeNumber_Validator_Js.invokeValidation],maxSize[{$FIELD->getRangeValues()}]]" value="{$FIELD->getEditValue($VALUE)}" {if $FIELD->isReadOnly()}readonly="readonly"{/if}/>
+	<input name="inventory[{$ROW_NO}][{$FIELD->getColumnName()}]" type="{$INPUT_TYPE}" class="form-control form-control-sm {$FIELD->getColumnName()} integerVal" data-validation-engine="validate[funcCall[Vtiger_Integer_Validator_Js.invokeValidation],maxSize[{$FIELD->getRangeValues()}]]" value="{$FIELD->getEditValue($VALUE)}" {if $FIELD->isReadOnly()}readonly="readonly"{/if}/>
 	<!-- /tpl-Base-inventoryfields-EditViewInteger -->
 {/strip}

--- a/layouts/basic/modules/Vtiger/inventoryfields/EditViewQuantity.tpl
+++ b/layouts/basic/modules/Vtiger/inventoryfields/EditViewQuantity.tpl
@@ -2,7 +2,7 @@
 {strip}
 	<!-- tpl-Base-inventoryfields-EditViewQuantity -->
 	{assign var=VALUE value=$FIELD->getValue($ITEM_VALUE)}
-	{assign var=VALIDATION_ENGINE value='validate[required,funcCall[Vtiger_NumberUserFormat_Validator_Js.invokeValidation]]'}
+	{assign var=VALIDATION_ENGINE value='validate[required,funcCall[Vtiger_Double_Validator_Js.invokeValidation]]'}
 	<div class="input-group input-group-sm">
 		<input name="inventory[{$ROW_NO}][{$FIELD->getColumnName()}]" type="text"
 			   class="qty smallInputBox form-control form-control-sm" data-maximumlength="{$FIELD->getRangeValues()}"

--- a/layouts/basic/modules/Vtiger/inventoryfields/EditViewUnitPrice.tpl
+++ b/layouts/basic/modules/Vtiger/inventoryfields/EditViewUnitPrice.tpl
@@ -5,7 +5,7 @@
 	<div class="input-group input-group-sm">
 		<input name="inventory[{$ROW_NO}][{$FIELD->getColumnName()}]" value="{$FIELD->getEditValue($VALUE)}" title="{$FIELD->getEditValue($VALUE)}" type="text"
 			   data-maximumlength="{$FIELD->getRangeValues()}"
-			   data-validation-engine="validate[required,funcCall[Vtiger_NumberUserFormat_Validator_Js.invokeValidation]]"
+			   data-validation-engine="validate[required,funcCall[Vtiger_Currency_Validator_Js.invokeValidation]]"
 			   class="unitPrice smallInputBox form-control form-control-sm" list-info="" {if $FIELD->isReadOnly()}readonly="readonly"{/if}/>
 
 		{assign var=PRICEBOOK_MODULE_MODEL value=Vtiger_Module_Model::getInstance('PriceBooks')}


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
All Validator engine is set to Vtiger_NumberUserFormat_Validator_Js as is Curency, double ect ... 

The patch set correct validation engine for the Type of inventory Field

## Testing
Create inventory, test value of UnitPrice, qty and Another double field

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [ x] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [x ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
