### PR TITLE
Correctly check Users Module in reference field

### DIFF
--- a/modules/Vtiger/uitypes/Reference.php
+++ b/modules/Vtiger/uitypes/Reference.php
@@ -105,8 +105,8 @@ class Vtiger_Reference_UIType extends Vtiger_Base_UIType
 	 */
 	public function getEditViewDisplayValue($value, $recordModel = false)
 	{
-		$referenceModuleName = $this->getReferenceModule($value);
-		if ('Users' === $referenceModuleName || 'Groups' === $referenceModuleName) {
+		$referenceModule = $this->getReferenceModule($value);
+		if ($referenceModule && ('Users' === $referenceModule->getName() || 'Groups' === $referenceModule->getName())) {
 			return \App\Fields\Owner::getLabel($value);
 		}
 		return \App\Record::getLabel($value);


### PR DESCRIPTION
## Description
On the uitype reference field, when the field references the Users or Group Module in EditView. The code is wrong and go to an empty field and Error : Module cannot be converted to str. 

## Testing
Do manualy refererence fiels to Users Module on any other module to select an user.
in detail view, all is OK , on edit view, you see the field empty. 

After the patch, all working fine, you can Edit ect ..
 
## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [x] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [x] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
