### PR TITLE
Permit to reference Users Field in inventory

### DIFF
--- a/modules/Vtiger/inventoryfields/Reference.php
+++ b/modules/Vtiger/inventoryfields/Reference.php
@@ -33,19 +33,26 @@ class Vtiger_Reference_InventoryField extends Vtiger_Basic_InventoryField
 	 */
 	public function getDisplayValue($value, array $rowData = [], bool $rawText = false)
 	{
-		if (empty($value) || !\App\Record::isExists($value)) {
+		if (empty($value) || !($referenceModule = $this->getReferenceModule($value))) {
 			return '';
 		}
+		$referenceModuleName = $referenceModule->getName();
+		if ('Users' === $referenceModuleName || 'Groups' === $referenceModuleName) {
+			return \App\Fields\Owner::getLabel($value);
+		}
+		if (!\App\Record::isExists($value)) {
+			return '';
+		}
+		
 		$label = \App\Record::getLabel($value);
-		$moduleName = \App\Record::getType($value);
-		if ($rawText || ($value && !\App\Privilege::isPermitted($moduleName, 'DetailView', $value))) {
+		if ($rawText || ($value && !\App\Privilege::isPermitted($referenceModuleName, 'DetailView', $value))) {
 			return $label;
 		}
 		$label = App\TextParser::textTruncate($label, \App\Config::main('href_max_length'));
 		if ('Active' !== \App\Record::getState($value)) {
 			$label = '<s>' . $label . '</s>';
 		}
-		return "<a class='modCT_$moduleName showReferenceTooltip js-popover-tooltip--record' href='index.php?module=$moduleName&view=Detail&record=$value' title='" . App\Language::translateSingularModuleName($moduleName) . "'>$label</a>";
+		return "<a class='modCT_$referenceModuleName showReferenceTooltip js-popover-tooltip--record' href='index.php?module=$referenceModuleName&view=Detail&record=$value' title='" . App\Language::translateSingularModuleName($referenceModuleName) . "'>$label</a>";
 	}
 
 	/**
@@ -55,6 +62,9 @@ class Vtiger_Reference_InventoryField extends Vtiger_Basic_InventoryField
 	{
 		if (empty($value)) {
 			return '';
+		}
+		if (($referenceModule = $this->getReferenceModule($value)) && ('Users' === $referenceModule->getName() || 'Groups' === $referenceModule->getName())) {
+			return \App\Fields\Owner::getLabel($value);
 		}
 		return \App\Record::getLabel($value);
 	}
@@ -83,8 +93,14 @@ class Vtiger_Reference_InventoryField extends Vtiger_Basic_InventoryField
 	{
 		if (!empty($record)) {
 			$metadata = vtlib\Functions::getCRMRecordMetadata($record);
-
-			return $metadata['setype'];
+			$referenceModuleList = $this->getReferenceModules();
+			$referenceEntityType = $metadata['setype'];
+			if (!empty($referenceModuleList) && \in_array($referenceEntityType, $referenceModuleList)) {
+				return Vtiger_Module_Model::getInstance($referenceEntityType);
+			}
+			if (!empty($referenceModuleList) && \in_array('Users', $referenceModuleList)) {
+				return Vtiger_Module_Model::getInstance('Users');
+			}
 		}
 		return '';
 	}


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
reference inventory field is not capable to reference Users Module to have a line with Users. 

## Testing
Make a reference field in inventory lines to Users module
the field work and show user in Detail and Edit View

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [x] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [x] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
