### PR TITLE
Error with "OR" conditions on Workflows

### DIFF
--- a/modules/com_vtiger_workflow/VTJsonCondition.php
+++ b/modules/com_vtiger_workflow/VTJsonCondition.php
@@ -93,10 +93,8 @@ class VTJsonCondition
 					if (!empty($logicalOperator)) {
 						switch ($logicalOperator) {
 							case 'and':
-								$finalResult = ($finalResult && $result);
-								break;
 							case 'or':
-								$finalResult = ($finalResult || $result);
+								$finalResult = ($finalResult && $result);
 								break;
 							default:
 								break;


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
Both conditions must be true, because if you only put "OR" conditions, the variable $finalResult will always be true since it is not modified anywhere else.

## Testing
Creating a Workflow only with OR conditions and other with AND and OR conditions

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [x] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
