### PR TITLE
Deprecated: Implicit conversion from float to int loses precision

### DIFF
--- a/app/Log/FileTarget.php
+++ b/app/Log/FileTarget.php
@@ -116,7 +116,7 @@ class FileTarget extends \yii\log\FileTarget
 		$micro = explode('.', $timestamp);
 		$micro = end($micro);
 
-		return date('Y-m-d H:i:s', $timestamp) . ".$micro [$level]$category - $text"
+		return date('Y-m-d H:i:s', $timestamp) . ".{$micro}[$level][$category] - $text"
 			. (empty($traces) ? '' : "\n" . $traces);
 	}
 

--- a/app/Log/FileTarget.php
+++ b/app/Log/FileTarget.php
@@ -116,7 +116,7 @@ class FileTarget extends \yii\log\FileTarget
 		$micro = explode('.', $timestamp);
 		$micro = end($micro);
 
-		return date('Y-m-d H:i:s', $timestamp) . ".{$micro}[$level][$category] - $text"
+		return date('Y-m-d H:i:s', $timestamp) . ".{$micro} [$level][$category] - $text"
 			. (empty($traces) ? '' : "\n" . $traces);
 	}
 


### PR DESCRIPTION
Deprecated: Implicit conversion from float 1640589929.314267 to int loses precision in /var/www/html/app/Log/FileTarget.php on line 119