### PR TITLE
PHP 8.1 VTJsonCondition/checkCondition nullable value secure [UnitTest]

### DIFF
--- a/modules/com_vtiger_workflow/VTJsonCondition.php
+++ b/modules/com_vtiger_workflow/VTJsonCondition.php
@@ -163,7 +163,7 @@ class VTJsonCondition
 		} else {
 			$fieldValue = $recordModel->get($cond['fieldname']);
 		}
-		$value = trim(html_entity_decode($cond['value']));
+		$value = trim(html_entity_decode($cond['value'] ?? ''));
 		$expressionType = $cond['valuetype'];
 		if ('fieldname' === $expressionType) {
 			if (null !== $referredRecordModel) {


### PR DESCRIPTION
refers to:


++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++++++++++++++++++++   Base Z_MultiImage -> testAttachImageToRecord with data set #1   ++++++++++++++++++++

Deprecated: html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/modules/com_vtiger_workflow/VTJsonCondition.php on line 166
