### PR TITLE
PHP 8.1 app/Colors/generateOwners() nullable value secure [UnitTest]

### DIFF
--- a/app/Colors.php
+++ b/app/Colors.php
@@ -58,7 +58,7 @@ class Colors
 		$css = '';
 		$colors = [];
 		foreach (static::getAllUserColor() as $item) {
-			if (ltrim($item['color'], '#')) {
+			if (ltrim($item['color'] ?? '', '#')) {
 				$css .= '.ownerCBg_' . $item['id'] . ' { background: ' . $item['color'] . ' !important; font-weight: 500 !important; color: ' . static::getContrast($item['color']) . ' !important;}' . PHP_EOL;
 				$css .= '.ownerCT_' . $item['id'] . ' { color: ' . $item['color'] . ' !important; }' . PHP_EOL;
 				$css .= '.ownerCBr_' . $item['id'] . ' { border-color: ' . $item['color'] . ' !important; }' . PHP_EOL;


### PR DESCRIPTION
refs to: 

++++++++++++++++++++   Settings Colors -> testGenerateColorsCss   ++++++++++++++++++++

Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/app/Colors.php on line 61
