### PR TITLE
PHP 8.1 & PackageExport/__write nullable value secure [UnitTest]

### DIFF
--- a/vtlib/Vtiger/PackageExport.php
+++ b/vtlib/Vtiger/PackageExport.php
@@ -67,7 +67,7 @@ class PackageExport
 
 	public function __write($value)
 	{
-		fwrite($this->_export_modulexml_file, $value);
+		fwrite($this->_export_modulexml_file, $value ?? '');
 	}
 
 	/**


### PR DESCRIPTION
refs to:

++++++++++++++++++++   Settings ModuleManager -> testExportModule   ++++++++++++++++++++

Deprecated: fwrite(): Passing null to parameter #2 ($data) of type string is deprecated in /var/www/html/vtlib/Vtiger/PackageExport.php on line 70

