### PR TITLE
Correct setting of check boxes of Inventory boolean fields depending on their values.

### DIFF
--- a/public_html/layouts/basic/modules/Vtiger/resources/Inventory.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/Inventory.js
@@ -1026,7 +1026,11 @@ $.Class(
 				thisInstance.setTaxPercent(parentRow, 0);
 				// Load auto fields
 				for (let field in recordData['autoFields']) {
-					parentRow.find('input.' + field).val(recordData['autoFields'][field]);
+					var inputField = parentRow.find('input.' + field);
+                    inputField.val(recordData['autoFields'][field]);
+                    if(inputField.attr('type')=='checkbox' && recordData['autoFields'][field]==true){
+                    	inputField.prop('checked',true);					
+					}
 					if (recordData['autoFields'][field + 'Text']) {
 						parentRow.find('.' + field + 'Text').text(recordData['autoFields'][field + 'Text']);
 					}

--- a/public_html/layouts/basic/modules/Vtiger/resources/Inventory.js
+++ b/public_html/layouts/basic/modules/Vtiger/resources/Inventory.js
@@ -1026,7 +1026,7 @@ $.Class(
 				thisInstance.setTaxPercent(parentRow, 0);
 				// Load auto fields
 				for (let field in recordData['autoFields']) {
-					var inputField = parentRow.find('input.' + field);
+					let inputField = parentRow.find('input.' + field);
                     inputField.val(recordData['autoFields'][field]);
                     if(inputField.attr('type')=='checkbox' && recordData['autoFields'][field]==true){
                     	inputField.prop('checked',true);					


### PR DESCRIPTION
Now the check-boxes of Inventory boolean fields will be set correctly regarding to their content.

<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
The check-boxes representing boolean inventory fields were always displayed as not checked. Now their visible status will be set accordingly to their database status.

## Testing

1. Create boolean inventory field in any advanced module. 
2. Create new record
3. Add inventory line 
4. Set boolean field to checked.
5. Save the record 
6. Edit the record again.
7. Now the boolean field should be checked.

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [X] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
