### PR TITLE
Fix: Changes in unit tests - changes in App/Zip files

### DIFF
--- a/tests/App/Zip.php
+++ b/tests/App/Zip.php
@@ -85,9 +85,8 @@ class Zip extends \Tests\Base
 	 */
 	public function testCreateFileBadDir(): void
 	{
-		$zip = \App\Zip::createFile(ROOT_DIRECTORY . '/tests/data/NxDir/NxFile.zip');
-		$zip->addFromString('filename.txt', '<minimal content>');
-		$this->expectWarning();
-		$this->assertFalse($zip->close());
+		$this->expectException(\App\Exceptions\AppException::class);
+		$this->expectExceptionMessage("Unable to create the zip file");
+		\App\Zip::createFile(ROOT_DIRECTORY . '/tests/data/NxDir/NxFile.zip');
 	}
 }


### PR DESCRIPTION
Commits includes changes for unit tests - App/Zip files.
Previously was not possible to pass App/Zip.

Method expectWarning() is actually deprecated. It's not available to create file in not exists folder. After call method createFile the exception will be throw.