### PR TITLE
Fix: Repair debug mode in console. Compatibility with extends class

### DIFF
--- a/app/Debug/DebugBar/TraceablePDOStatement.php
+++ b/app/Debug/DebugBar/TraceablePDOStatement.php
@@ -32,7 +32,7 @@ class TraceablePDOStatement extends \DebugBar\DataCollector\PDO\TraceablePDOStat
 	 *
 	 * @return bool TRUE on success or FALSE on failure.
 	 */
-	public function execute($input_parameters = null)
+	public function execute($input_parameters = null): bool
 	{
 		$this->boundParameters['backtrace'] = \App\Debuger::getBacktrace(4);
 		$this->boundParameters['driverName'] = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);


### PR DESCRIPTION
<!--- If your pull request includes a script, please submit it [here] (https://github.com/YetiForceCompany/YetiForceScripts) -->

## Description
When we turned on options associated with option "debug console" we receive an error about compatibility with extends class.

Before:

![debugMode error](https://github.com/YetiForceCompany/YetiForceCRM/assets/137064478/bdfd7811-25e1-4dd2-b22c-3f74816b0fd6)

 