### PR TITLE
Removed strftime function - no support since php 8.1

### DIFF
--- a/modules/com_vtiger_workflow/expression_engine/VTExpressionEvaluater.php
+++ b/modules/com_vtiger_workflow/expression_engine/VTExpressionEvaluater.php
@@ -179,8 +179,9 @@ class VTFieldExpressionEvaluater
 			$baseDate = date('Y-m-d'); // Current date
 		}
 		preg_match('/\d\d\d\d-\d\d-\d\d/', $baseDate, $match);
-		$baseDate = strtotime($match[0]);
-		return strftime('%Y-%m-%d', $baseDate + ($noOfDays * 24 * 60 * 60));
+		$date = new DateTime($match[0]);
+		$date->modify("+ $noOfDays days");
+		return $date->format('Y-m-d');
 	}
 
 	public static function __vt_sub_days($arr)
@@ -195,8 +196,9 @@ class VTFieldExpressionEvaluater
 			$baseDate = date('Y-m-d'); // Current date
 		}
 		preg_match('/\d\d\d\d-\d\d-\d\d/', $baseDate, $match);
-		$baseDate = strtotime($match[0]);
-		return strftime('%Y-%m-%d', $baseDate - ($noOfDays * 24 * 60 * 60));
+		$date = new DateTime($match[0]);
+		$date->modify("- $noOfDays days");
+		return $date->format('Y-m-d');
 	}
 
 	public static function __vt_get_date($arr)

--- a/modules/com_vtiger_workflow/expression_engine/VTExpressionEvaluater.php
+++ b/modules/com_vtiger_workflow/expression_engine/VTExpressionEvaluater.php
@@ -180,8 +180,7 @@ class VTFieldExpressionEvaluater
 		}
 		preg_match('/\d\d\d\d-\d\d-\d\d/', $baseDate, $match);
 		$date = new DateTime($match[0]);
-		$date->modify("+ $noOfDays days");
-		return $date->format('Y-m-d');
+		return $date->modify("+ $noOfDays days")->format('Y-m-d');
 	}
 
 	public static function __vt_sub_days($arr)
@@ -197,8 +196,7 @@ class VTFieldExpressionEvaluater
 		}
 		preg_match('/\d\d\d\d-\d\d-\d\d/', $baseDate, $match);
 		$date = new DateTime($match[0]);
-		$date->modify("- $noOfDays days");
-		return $date->format('Y-m-d');
+		return $date->modify("- $noOfDays days")->format('Y-m-d');
 	}
 
 	public static function __vt_get_date($arr)


### PR DESCRIPTION
Removed strftime function - no support since php 8.1


- the old code doesn't change the date when float type

- new code with float type shows error:
"Failed to parse time string (+ 0.9 days) at position 0 (+): Unexpected character"