### PR TITLE
Fixed quick export to xls

### DIFF
--- a/modules/Vtiger/models/ExportToSpreadsheet.php
+++ b/modules/Vtiger/models/ExportToSpreadsheet.php
@@ -153,7 +153,7 @@ class Vtiger_ExportToSpreadsheet_Model extends \App\Export\Records
 				}
 				break;
 			default:
-				$displayValue = $this->getDisplayValue($fieldModel, $value, $id, []) ?: '';
+				$displayValue = $this->getDisplayValue($fieldModel, $value, $id, []);
 				$this->workSheet->setCellValueExplicitByColumnAndRow($this->colNo, $this->rowNo, $displayValue, \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
 		}
 		++$this->colNo;


### PR DESCRIPTION
When you have a picklist with numbers 0,1,2,3 as values. Value 0 is represented as empty string