### PR TITLE
fix for not checking deleted flag in getCrmIdByLabel

### DIFF
--- a/app/Record.php
+++ b/app/Record.php
@@ -80,6 +80,7 @@ class Record
 			->from('u_#__crmentity_label cl')
 			->innerJoin('vtiger_crmentity', 'cl.crmid = vtiger_crmentity.crmid')
 			->where(['vtiger_crmentity.setype' => $moduleName])
+			->andWhere(['vtiger_crmentity.deleted' => 0])
 			->andWhere(['cl.label' => $label]);
 		if ($userId) {
 			$query->andWhere(['like', 'vtiger_crmentity.users', ",$userId,"]);


### PR DESCRIPTION
missing check for crmentity deleted flag

causing import to match deleted records


## Description
added check for deleted flag in crmentity table

## Testing
Import a quote that has a product with name that matches a product that has both an older deleted record and a newer on with the same name.

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [ X] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
